### PR TITLE
Add /lyrics directory page to template

### DIFF
--- a/site-template/src/lib/components/layout/Header.svelte
+++ b/site-template/src/lib/components/layout/Header.svelte
@@ -30,10 +30,10 @@
 		</div>
 		<nav>
 			<HeaderLink href="/music" title="Music" />
+			<HeaderLink href="/lyrics" title="Lyrics" />
 			{#if gigs.length > 0}
 				<HeaderLink href="/live" title="Live" />
 			{/if}
-			<HeaderLink href="/contact" title="Contact" />
 			{#if artistDetails.storeUrl}
 				<HeaderLink href={artistDetails.storeUrl} title="Shop" targetBlank />
 			{/if}

--- a/site-template/src/routes/lyrics/+page.server.ts
+++ b/site-template/src/routes/lyrics/+page.server.ts
@@ -1,0 +1,7 @@
+import { releases } from '../../data/info/releases';
+
+export function load() {
+	return {
+		releases
+	};
+}

--- a/site-template/src/routes/lyrics/+page.svelte
+++ b/site-template/src/routes/lyrics/+page.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+	import { artistDetails } from '../../data/info/artist.js';
+	import { slugifyName } from '$lib/utils/utils.js';
+	import type { Release } from '../../data/interfaces/releases.js';
+
+	export let data: {
+		releases: Release[];
+	};
+
+	$: setting = 'all';
+
+	const allTracksWithParentSlug = data.releases
+		.flatMap((release) => {
+			const { slug } = release;
+			return release.tracks.map((track) => ({
+				...track,
+				parentRelease: slug
+			}));
+		})
+		.sort((a, b) => a.name.localeCompare(b.name));
+</script>
+
+<svelte:head>
+	<title>Lyrics · {artistDetails.name}</title>
+	<meta name="description" content="Explore the lyrics for songs by {artistDetails.name}." />
+</svelte:head>
+
+<div class="container">
+	<h2>Lyrics</h2>
+	<div class="options">
+		<div class={setting === 'all' ? 'active-option' : ''} on:click={() => (setting = 'all')}>
+			All
+		</div>
+		<div
+			class={setting === 'releases' ? 'active-option' : ''}
+			on:click={() => (setting = 'releases')}
+		>
+			By release
+		</div>
+	</div>
+
+	<div class="tracks-list">
+		<div class={`all-list ${setting === 'all' ? 'active' : 'hidden'}`}>
+			{#each allTracksWithParentSlug as track}
+				{#if track.lyrics}
+					<div>
+						<a
+							href={`/music/${slugifyName(track.parentRelease)}/${slugifyName(track.name)}#lyrics`}
+						>
+							{track.name}
+						</a>
+					</div>
+				{/if}
+			{/each}
+		</div>
+		<div class={`release-list ${setting === 'releases' ? 'active' : 'hidden'}`}>
+			{#each data.releases as release}
+				<div class="release-container">
+					<h3>{release.name}</h3>
+					{#each release.tracks as track}
+						{#if track.lyrics}
+							<div>
+								<a href={`/music/${release.slug}/${slugifyName(track.name)}#lyrics`}>
+									{track.name}
+								</a>
+							</div>
+						{/if}
+					{/each}
+				</div>
+			{/each}
+		</div>
+	</div>
+</div>
+
+<style>
+	.container {
+		padding: 0 1rem;
+	}
+
+	.options {
+		display: flex;
+		justify-content: center;
+		margin-bottom: 2rem;
+	}
+
+	.options div {
+		padding: 0.3rem 0.7rem 0.2rem 0.7rem;
+		border-radius: 7px;
+	}
+
+	.options div:hover {
+		cursor: pointer;
+	}
+
+	.active-option {
+		font-weight: 500;
+		background-color: #323232;
+		color: lightgray;
+	}
+
+	h2 {
+		margin-bottom: 1rem;
+	}
+	h3 {
+		font-size: 1.4rem;
+	}
+
+	.tracks-list {
+		text-align: center;
+	}
+	.release-container {
+		margin-bottom: 2rem;
+	}
+	.active {
+		display: block;
+	}
+	.hidden {
+		display: none;
+	}
+</style>

--- a/site-template/src/routes/music/[slug]/[slug]/+page.svelte
+++ b/site-template/src/routes/music/[slug]/[slug]/+page.svelte
@@ -61,7 +61,7 @@
 	{/if}
 
 	{#if data.track.lyrics}
-		<h3>Lyrics</h3>
+		<h3 id="lyrics">Lyrics</h3>
 		<LyricsSheet lyrics={data.track.lyrics} />
 	{/if}
 


### PR DESCRIPTION
This updates the site template to include a lyrics directory page. Using the same core releases dataset, it lists all tracks with lyrics and links to the appropriate section of their page.

![image](https://github.com/user-attachments/assets/3d5c7cad-a02e-457e-b177-439ed889c86c)
![image](https://github.com/user-attachments/assets/2c592d1f-6258-454e-949b-1905123f6e04)

Based on feedback from musicians so far this felt like a no-brainer while preserving the structure of the main music archive. And as it turns out super simple to implement using the data we already have.