### PR TITLE
Rejig interplay between Supabase data and IPFS files

### DIFF
--- a/app/src/lib/components/ReleaseCardGrid.svelte
+++ b/app/src/lib/components/ReleaseCardGrid.svelte
@@ -1,27 +1,26 @@
 <script lang="ts">
-	import type { Release } from '$lib/types';
+	import type { ReleaseHydrated } from '$lib/types';
+	import { makeImageLink } from '$lib/utils';
 	import ReleaseCard from './ReleaseCard.svelte';
 
 	let {
 		releases,
 		hideArtistName = false
 	}: {
-		releases: Release[];
+		releases: ReleaseHydrated[];
 		hideArtistName?: boolean;
 	} = $props();
 </script>
 
 <div class="releases-grid">
 	{#each releases as release}
-		{#if release.coverLink && release.artistName}
-			<ReleaseCard
-				link={`/releases/${release.id}`}
-				name={release.title}
-				artist={release.artistName}
-				coverArt={release.coverLink}
-				hideArtist={hideArtistName}
-			/>
-		{/if}
+		<ReleaseCard
+			link={`/releases/${release.id}`}
+			name={release.title}
+			artist={release.artist_name}
+			coverArt={makeImageLink(release.artwork_ipfs_cid)}
+			hideArtist={hideArtistName}
+		/>
 	{/each}
 </div>
 

--- a/app/src/lib/global/config.ts
+++ b/app/src/lib/global/config.ts
@@ -9,8 +9,9 @@ export const PUBLIC_SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
 export const PUBLIC_SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export const TABLES = {
-	listeners: 'profiles',
-	artists: 'artist-profiles',
+	users: 'users',
+	artists: 'artists',
+	releasesHydrated: 'hydrated_releases',
 	streams: 'streams',
 	betaUsers: 'beta-users'
 };

--- a/app/src/lib/global/state.svelte.ts
+++ b/app/src/lib/global/state.svelte.ts
@@ -1,4 +1,4 @@
-import type { ArtistManifest, Track, UserState } from '$lib/types';
+import type { TrackRaw, UserState } from '$lib/types';
 import { createClient } from '@supabase/supabase-js';
 import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL, TABLES } from './config';
 
@@ -6,6 +6,7 @@ const supabase = createClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY);
 
 export const userState: UserState = $state({
 	activeSong: null,
+	activeSongUrl: null,
 	activeSongArtist: null,
 	liveBalance: 0,
 	payPerStream: 3
@@ -32,7 +33,7 @@ const logStream = async (userId: string, artistId: string, trackId: string, toke
 const updateUserBalance = async (userId: string, newBalance: number) => {
 	console.log('Updating balance for user:', userId, 'New balance:', newBalance);
 	const { error } = await supabase
-		.from(TABLES.listeners)
+		.from(TABLES.users)
 		.update({ tokens_balance: newBalance })
 		.eq('id', userId)
 		.select();
@@ -44,9 +45,12 @@ const updateUserBalance = async (userId: string, newBalance: number) => {
 	}
 };
 
-export const setActiveSong = (
-	song: Track,
-	artist: ArtistManifest,
+export const setActiveSong = async (
+	song: TrackRaw,
+	artist: {
+		artistId: string;
+		artistName: string;
+	},
 	userId: string,
 	userBalance: number,
 	userPayPerStream: number
@@ -54,12 +58,17 @@ export const setActiveSong = (
 	if (userBalance < userPayPerStream) {
 		throw new Error('Not enough balance to play this song');
 	}
+
+	const songUrl = await fetch('/api/links/' + song.ipfs_cid).then((res) => res.text());
+
 	userState.activeSong = song;
 	userState.activeSongArtist = artist;
+	userState.activeSongUrl = songUrl;
+
 	// TODO: Improve this to use a more accurate timer
 	// Deduct the pay per stream after 30 of playtime
 	setTimeout(() => {
 		updateUserBalance(userId, userBalance - userPayPerStream);
-		logStream(userId, artist.artist.id, song.name, userPayPerStream);
+		logStream(userId, artist.artistId, song.id, userPayPerStream);
 	}, 30000);
 };

--- a/app/src/lib/server/pinata.ts
+++ b/app/src/lib/server/pinata.ts
@@ -1,7 +1,6 @@
 import { PinataSDK } from 'pinata';
 import { PINATA_JWT, PINATA_GROUP_MANIFESTS } from '$env/static/private';
 import { PUBLIC_GATEWAY_URL } from '$env/static/public';
-import type { ArtistManifest } from '$lib/types';
 
 export const pinata = new PinataSDK({
 	pinataJwt: `${PINATA_JWT}`,
@@ -12,14 +11,10 @@ export const pinataGroups = {
 	manifests: PINATA_GROUP_MANIFESTS
 };
 
-export const getManifests = async () => {
-	const manifests = await pinata.files.public.list().group(pinataGroups.manifests);
-
-	const allManifests = (await Promise.all(
-		manifests.files.map(async (manifest) => {
-			const { data } = await pinata.gateways.public.get(manifest.cid);
-			return data;
-		})
-	)) as unknown as ArtistManifest[];
-	return allManifests;
+export const getSongUrl = async (cid: string) => {
+	const url = await pinata.gateways.private.createAccessLink({
+		cid,
+		expires: 5
+	});
+	return url;
 };

--- a/app/src/lib/server/supabase.ts
+++ b/app/src/lib/server/supabase.ts
@@ -1,0 +1,4 @@
+import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL } from '$lib/global/config';
+import { createClient } from '@supabase/supabase-js';
+
+export const supabase = createClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY);

--- a/app/src/lib/types/index.ts
+++ b/app/src/lib/types/index.ts
@@ -1,82 +1,3 @@
-export interface ArtistRaw {
-	id: string;
-	name: string;
-	description: string;
-	website: string;
-	imageCID?: string;
-}
-
-export interface ArtistHydrated {
-	id: string;
-	name: string;
-	description: string;
-	website: string;
-	imageLink?: string;
-}
-
-export interface TrackOld {
-	CID: string;
-	name: string;
-	durationInSeconds: number; // Duration in seconds
-	url: string; // URL to the track
-}
-
-export interface ReleaseRaw {
-	id: string;
-	name: string;
-	type: 'LP' | 'EP' | 'Single';
-	artistCID: string;
-	releaseDate: string;
-	coverCID: string;
-	tracks: TrackOld[];
-}
-
-export interface ReleaseHydrated {
-	id: string;
-	name: string;
-	type: 'LP' | 'EP' | 'Single';
-	artist: ArtistRaw;
-	releaseDate: string;
-	coverLink: string;
-	tracks: TrackOld[];
-}
-
-// Types revised
-
-export interface Track {
-	name: string;
-	duration_in_seconds: number;
-	cid: string;
-	url?: string; // URL to the track
-}
-
-export interface Release {
-	id: string;
-	title: string;
-	// TODO: Handle addition of artistName to the release
-	artistName?: string;
-	type: 'LP' | 'EP' | 'Single';
-	release_date: string;
-	cover_cid: string;
-	// TODO: Handle hydration of cover_cid to coverLink
-	coverLink?: string;
-	genres: string[];
-	tracks: Track[];
-}
-
-export interface ArtistManifest {
-	artist: {
-		id: string;
-		name: string;
-		description: string;
-		website: string;
-		image_cid: string;
-		// TODO: Handle hydration of image_cid to imageLink
-		imageLink?: string;
-	};
-	releases: Release[];
-}
-
 export interface UserProfile {
 	first_name: string;
 	tokens_balance: number;
@@ -84,8 +5,60 @@ export interface UserProfile {
 }
 
 export interface UserState {
-	activeSong: Track | null;
-	activeSongArtist: ArtistManifest | null;
+	activeSong: TrackRaw | null;
+	activeSongUrl: string | null;
+	activeSongArtist: {
+		artistId: string;
+		artistName: string;
+	} | null;
 	liveBalance: number | null;
 	payPerStream: number;
 }
+
+export interface ArtistRaw {
+	id: string;
+	name: string;
+	bio?: string;
+	website_url?: string;
+	stripe_account_id: string;
+	created_at: string;
+	image_ipfs_cid?: string;
+}
+
+export interface TrackRaw {
+	id: string;
+	artist_id: string;
+	release_id: string;
+	title: string;
+	ipfs_cid: string;
+	manifest_cid?: string;
+	duration_seconds: number;
+	created_at: string;
+}
+
+export interface ReleaseHydrated {
+	id: string;
+	title: string;
+	artwork_ipfs_cid: string;
+	release_type: string;
+	release_date: string;
+	artist_id: string;
+	artist_name: string;
+	tags: string[];
+	tracks: TrackRaw[];
+}
+
+// Not currently using as the API returns the hydrated version
+
+// export interface ReleaseRaw {
+// 	id: string;
+// 	artist_id: string;
+// 	title: string;
+// 	release_type: string;
+// 	artwork_ipfs_cid: string;
+// 	release_date: string;
+// 	tags: string[];
+// 	ipfs_manifest_cid?: string;
+// 	created_at: string;
+// 	updated_at: string;
+// }

--- a/app/src/lib/utils/index.ts
+++ b/app/src/lib/utils/index.ts
@@ -1,3 +1,5 @@
+import { PUBLIC_GATEWAY_URL } from '$env/static/public';
+
 export const prettifyDuration = (durationInSeconds: number) => {
 	const minutes = Math.floor(durationInSeconds / 60);
 	const seconds = durationInSeconds % 60;
@@ -12,4 +14,8 @@ export const prettifyPennies = (pence: number) => {
 	const pounds = Math.floor(pence / 100);
 	const pennies = pence % 100;
 	return `£${pounds}.${pennies < 10 ? '0' : ''}${pennies}`;
+};
+
+export const makeImageLink = (cid: string) => {
+	return 'https://' + PUBLIC_GATEWAY_URL + '/ipfs/' + cid;
 };

--- a/app/src/routes/+layout.server.ts
+++ b/app/src/routes/+layout.server.ts
@@ -14,7 +14,7 @@ export const load: LayoutServerLoad = async ({ locals: { supabase, safeGetSessio
 		}: {
 			data: UserProfile | null;
 		} = await supabase
-			.from(TABLES.listeners)
+			.from(TABLES.users)
 			.select(`first_name, tokens_balance, pay_per_stream`)
 			.eq('id', session.user.id)
 			.single();

--- a/app/src/routes/+layout.svelte
+++ b/app/src/routes/+layout.svelte
@@ -35,14 +35,14 @@
 	<div class="audio-player">
 		<!-- <div>Current balance: {prettifyBalance(userState.liveBalance)} tokens</div> -->
 		<div>
-			{userState.activeSong.name} by
-			<a href={`/artists/${userState.activeSongArtist.artist.id}`}
-				>{userState.activeSongArtist.artist.name}</a
+			{userState.activeSong.title} by
+			<a href={`/artists/${userState.activeSongArtist.artistId}`}
+				>{userState.activeSongArtist.artistName}</a
 			>
 		</div>
-		{#key userState.activeSong.url}
+		{#key userState.activeSong.ipfs_cid}
 			<audio controls autoplay controlsList="nodownload noplaybackrate">
-				<source src={userState.activeSong.url} type="audio/mpeg" />
+				<source src={userState.activeSongUrl} type="audio/mpeg" />
 				Your browser does not support the audio element.
 			</audio>
 		{/key}

--- a/app/src/routes/+page.server.ts
+++ b/app/src/routes/+page.server.ts
@@ -1,34 +1,11 @@
-import { pinata } from '$lib/server/pinata';
-import type { ArtistManifest } from '$lib/types/index.js';
+import type { ArtistRaw, ReleaseHydrated } from '$lib/types/index.js';
 
 export const load = async ({ fetch }) => {
-	const rawManifests: ArtistManifest[] = await fetch('/api/artists').then((res) => res.json());
-
-	// Hydrate the manifests with image links and release artwork links
-	const manifests = await Promise.all(
-		rawManifests.map(async (manifest) => {
-			const artistImageLink = await pinata.gateways.public.convert(manifest.artist.image_cid);
-			const releasesWithLinks = await Promise.all(
-				manifest.releases.map(async (release) => {
-					const coverLink = await pinata.gateways.public.convert(release.cover_cid);
-					return {
-						...release,
-						coverLink
-					};
-				})
-			);
-			return {
-				...manifest,
-				artist: {
-					...manifest.artist,
-					imageLink: artistImageLink
-				},
-				releases: releasesWithLinks
-			};
-		})
-	);
+	const artists: ArtistRaw[] = await fetch('/api/artists').then((res) => res.json());
+	const releases: ReleaseHydrated[] = await fetch('/api/releases').then((res) => res.json());
 
 	return {
-		manifests
+		artists,
+		releases
 	};
 };

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -1,20 +1,10 @@
 <script lang="ts">
 	import ArtistCard from '$lib/components/ArtistCard.svelte';
 	import ReleaseCardGrid from '$lib/components/ReleaseCardGrid.svelte';
+	import { makeImageLink } from '$lib/utils';
 	import type { PageProps } from './$types';
 
 	let { data }: PageProps = $props();
-
-	const releases = data.manifests
-		.map((manifest) => {
-			return manifest.releases.map((release) => {
-				return {
-					...release,
-					artistName: manifest.artist.name
-				};
-			});
-		})
-		.flat();
 </script>
 
 <svelte:head>
@@ -25,15 +15,21 @@
 <section>
 	<a href="/releases"><h2>Releases</h2></a>
 
-	<ReleaseCardGrid {releases} />
+	<ReleaseCardGrid releases={data.releases} />
 </section>
 
 <section>
 	<a href="/artists"><h2>Artists</h2></a>
 
 	<div class="artists-container">
-		{#each data.manifests as { artist }}
-			<ArtistCard link={`/artists/${artist.id}`} name={artist.name} image={artist.imageLink} />
+		{#each data.artists as artist}
+			<ArtistCard
+				link={`/artists/${artist.id}`}
+				name={artist.name}
+				image={artist.image_ipfs_cid
+					? makeImageLink(artist.image_ipfs_cid)
+					: '/person-placeholder.png'}
+			/>
 		{/each}
 	</div>
 </section>

--- a/app/src/routes/account/+page.server.ts
+++ b/app/src/routes/account/+page.server.ts
@@ -20,7 +20,7 @@ export const actions: Actions = {
 
 		const { session } = await safeGetSession();
 
-		const { error } = await supabase.from(TABLES.listeners).upsert({
+		const { error } = await supabase.from(TABLES.users).upsert({
 			id: session?.user.id,
 			first_name: firstName,
 			updated_at: new Date(),

--- a/app/src/routes/api/artists/+server.ts
+++ b/app/src/routes/api/artists/+server.ts
@@ -1,10 +1,21 @@
-// Returns all the artist manifests
-
+import { TABLES } from '$lib/global/config';
+import { supabase } from '$lib/server/supabase';
+import type { ArtistRaw } from '$lib/types';
 import { json } from '@sveltejs/kit';
-import { getManifests } from '$lib/server/pinata';
 
 export async function GET() {
-	const allManifests = await getManifests();
+	const {
+		data,
+		error
+	}: {
+		data: ArtistRaw[] | null;
+		error: Error | null;
+	} = await supabase.from(TABLES.artists).select();
 
-	return json(allManifests);
+	if (error || !data) {
+		console.error('Error fetching artist data:', error);
+		return json({ error: 'Failed to fetch artist data' }, { status: 500 });
+	}
+
+	return json(data);
 }

--- a/app/src/routes/api/checkout/success/+server.ts
+++ b/app/src/routes/api/checkout/success/+server.ts
@@ -16,7 +16,7 @@ export const POST: RequestHandler = async ({ request, locals: { supabase } }) =>
 		const topUpTokens = Math.round(topUpAmount * REVENUE_SPLIT.artists);
 
 		const { error } = await supabase
-			.from(TABLES.listeners)
+			.from(TABLES.users)
 			.update({
 				tokens_balance: topUpTokens + userTokensBalance
 			})

--- a/app/src/routes/api/links/[slug]/+server.ts
+++ b/app/src/routes/api/links/[slug]/+server.ts
@@ -1,0 +1,18 @@
+import { json, text } from '@sveltejs/kit';
+import { getSongUrl } from '$lib/server/pinata';
+
+export async function GET({ params, locals: { safeGetSession } }) {
+	const session = await safeGetSession();
+
+	if (!session) {
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+
+	const url = await getSongUrl(params.slug);
+
+	if (!url) {
+		return json({ error: 'Failed to fetch song URL' }, { status: 500 });
+	}
+
+	return text(url);
+}

--- a/app/src/routes/api/releases/+server.ts
+++ b/app/src/routes/api/releases/+server.ts
@@ -1,22 +1,21 @@
-// Returns all the releases from all the manifests
-
 import { json } from '@sveltejs/kit';
-import type { Release } from '$lib/types';
-import { getManifests } from '$lib/server/pinata';
+import { supabase } from '$lib/server/supabase';
+import { TABLES } from '$lib/global/config';
+import type { ReleaseHydrated } from '$lib/types';
 
 export async function GET() {
-	const allManifests = await getManifests();
+	const {
+		data,
+		error
+	}: {
+		data: ReleaseHydrated[] | null;
+		error: Error | null;
+	} = await supabase.from(TABLES.releasesHydrated).select();
 
-	const allReleases: Release[] = allManifests
-		.map((manifest) => {
-			return manifest.releases.map((release) => {
-				return {
-					...release,
-					artistName: manifest.artist.name
-				};
-			});
-		})
-		.flat();
+	if (error || !data) {
+		console.error('Error fetching artist data:', error);
+		return json({ error: 'Failed to fetch artist data' }, { status: 500 });
+	}
 
-	return json(allReleases);
+	return json(data);
 }

--- a/app/src/routes/artists/+page.server.ts
+++ b/app/src/routes/artists/+page.server.ts
@@ -1,24 +1,9 @@
-import { pinata } from '$lib/server/pinata';
-import type { ArtistManifest } from '$lib/types/index.js';
+import type { ArtistRaw } from '$lib/types/index.js';
 
 export const load = async ({ fetch }) => {
-	const artists: ArtistManifest[] = await fetch('/api/artists').then((res) => res.json());
-
-	const artistsWithLinks = await Promise.all(
-		artists.map(async (artist) => {
-			if (!artist.artist.image_cid) return artist;
-			const imageLink = await pinata.gateways.public.convert(artist.artist.image_cid);
-			return {
-				...artist,
-				artist: {
-					...artist.artist,
-					imageLink
-				}
-			};
-		})
-	);
+	const artists: ArtistRaw[] = await fetch('/api/artists').then((res) => res.json());
 
 	return {
-		artistsWithLinks
+		artists
 	};
 };

--- a/app/src/routes/artists/+page.svelte
+++ b/app/src/routes/artists/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import ArtistCard from '$lib/components/ArtistCard.svelte';
-	import type { ArtistHydrated, ArtistManifest } from '$lib/types';
+	import { makeImageLink } from '$lib/utils';
 
-	let { data }: { data: { artistsWithLinks: ArtistManifest[] } } = $props();
+	let { data } = $props();
 </script>
 
 <svelte:head>
@@ -13,8 +13,14 @@
 <h2>Artists</h2>
 
 <div class="artists-container">
-	{#each data.artistsWithLinks as { artist }}
-		<ArtistCard link={`/artists/${artist.id}`} name={artist.name} image={artist.imageLink} />
+	{#each data.artists as artist}
+		<ArtistCard
+			link={`/artists/${artist.id}`}
+			name={artist.name}
+			image={artist.image_ipfs_cid
+				? makeImageLink(artist.image_ipfs_cid)
+				: '/person-placeholder.png'}
+		/>
 	{/each}
 </div>
 

--- a/app/src/routes/artists/[slug]/+page.server.ts
+++ b/app/src/routes/artists/[slug]/+page.server.ts
@@ -1,21 +1,20 @@
-import { getManifests, pinata } from '$lib/server/pinata';
-import type { ArtistManifest } from '$lib/types/index.js';
+import type { ArtistRaw, ReleaseHydrated } from '$lib/types/index.js';
 
 // TODO: Explore static generation where possible to
 // improve performance and keep requests to a minimum
 
 export const entries = async () => {
-	const manifests = await getManifests();
-	const slugs = manifests.map((manifest) => {
-		return { slug: manifest.artist.id };
+	const artists: ArtistRaw[] = await fetch('/api/artists').then((res) => res.json());
+	const slugs = artists.map((artist) => {
+		return { slug: artist.id };
 	});
 	return slugs;
 };
 
-export const load = async ({ fetch, params }) => {
-	const manifests: ArtistManifest[] = await fetch('/api/artists').then((res) => res.json());
+export const load = async ({ params, fetch }) => {
+	const artists: ArtistRaw[] = await fetch('/api/artists').then((res) => res.json());
 
-	const matchingArtist = manifests.find((artist) => artist.artist.id === params.slug);
+	const matchingArtist = artists.find((artist) => artist.id === params.slug);
 
 	if (!matchingArtist) {
 		return {
@@ -24,26 +23,12 @@ export const load = async ({ fetch, params }) => {
 		};
 	}
 
-	const artistWithLinks = await Promise.all(
-		matchingArtist.releases.map(async (release) => {
-			const coverLink = await pinata.gateways.public.convert(release.cover_cid);
-			return {
-				...release,
-				coverLink
-			};
-		})
-	);
+	const allReleases: ReleaseHydrated[] = await fetch(`/api/releases`).then((res) => res.json());
 
-	const artistImageLink = await pinata.gateways.public.convert(matchingArtist.artist.image_cid);
+	const artistReleases = allReleases.filter((release) => release.artist_id === matchingArtist.id);
 
 	return {
-		artistManifest: {
-			...matchingArtist,
-			artist: {
-				...matchingArtist.artist,
-				imageLink: artistImageLink
-			},
-			releases: artistWithLinks
-		}
+		artist: matchingArtist,
+		releases: artistReleases
 	};
 };

--- a/app/src/routes/artists/[slug]/+page.server.ts
+++ b/app/src/routes/artists/[slug]/+page.server.ts
@@ -1,15 +1,8 @@
 import type { ArtistRaw, ReleaseHydrated } from '$lib/types/index.js';
 
 // TODO: Explore static generation where possible to
-// improve performance and keep requests to a minimum
-
-export const entries = async () => {
-	const artists: ArtistRaw[] = await fetch('/api/artists').then((res) => res.json());
-	const slugs = artists.map((artist) => {
-		return { slug: artist.id };
-	});
-	return slugs;
-};
+// improve performance and keep requests to a minimum.
+// May entail splitting the API into its own thing.
 
 export const load = async ({ params, fetch }) => {
 	const artists: ArtistRaw[] = await fetch('/api/artists').then((res) => res.json());

--- a/app/src/routes/artists/[slug]/+page.svelte
+++ b/app/src/routes/artists/[slug]/+page.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
 	import ReleaseCardGrid from '$lib/components/ReleaseCardGrid.svelte';
-	import type { ArtistHydrated, ArtistManifest, ReleaseHydrated } from '$lib/types';
+	import type { ArtistRaw, ReleaseHydrated } from '$lib/types';
+	import { makeImageLink } from '$lib/utils';
 
-	let { data }: { data: { artistManifest: ArtistManifest } } = $props();
+	let { data }: { data: { artist: ArtistRaw; releases: ReleaseHydrated[] } } = $props();
 
-	const { name, description, website } = data.artistManifest.artist;
+	const { name, bio, website_url, image_ipfs_cid } = data.artist;
 
-	const lps = data.artistManifest.releases.filter((release) => release.type === 'LP');
-	const eps = data.artistManifest.releases.filter((release) => release.type === 'EP');
-	const singles = data.artistManifest.releases.filter((release) => release.type === 'Single');
+	const lps = data.releases.filter((release) => release.release_type === 'lp');
+	const eps = data.releases.filter((release) => release.release_type === 'ep');
+	const singles = data.releases.filter((release) => release.release_type === 'single');
 </script>
 
 <svelte:head>
@@ -20,13 +21,15 @@
 
 <h2>{name}</h2>
 
-{#if data.artistManifest.artist.imageLink}
-	<img src={data.artistManifest.artist.imageLink} alt={`Image of ${name}`} />
+{#if image_ipfs_cid}
+	<img src={makeImageLink(image_ipfs_cid)} alt={`Image of ${name}`} />
 {/if}
 
-<div>{description}</div>
+<div>{bio}</div>
 
-<a href={website}>{website.replace('https://', '').replaceAll('/', '')}</a>
+{#if data.artist.website_url}
+	<a href={website_url}>{website_url?.replace('https://', '').replaceAll('/', '')}</a>
+{/if}
 
 <h3>Music</h3>
 

--- a/app/src/routes/releases/+page.server.ts
+++ b/app/src/routes/releases/+page.server.ts
@@ -1,20 +1,9 @@
-import { pinata } from '$lib/server/pinata';
-import type { Release } from '$lib/types/index';
+import type { ReleaseHydrated } from '$lib/types/index';
 
 export const load = async ({ fetch }) => {
-	const releases: Release[] = await fetch('/api/releases').then((res) => res.json());
-
-	const releasesWithLinks = await Promise.all(
-		releases.map(async (release) => {
-			const coverLink = await pinata.gateways.public.convert(release.cover_cid);
-			return {
-				...release,
-				coverLink
-			};
-		})
-	);
+	const releases: ReleaseHydrated[] = await fetch('/api/releases').then((res) => res.json());
 
 	return {
-		releases: releasesWithLinks
+		releases
 	};
 };

--- a/app/src/routes/releases/+page.svelte
+++ b/app/src/routes/releases/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import ReleaseCardGrid from '$lib/components/ReleaseCardGrid.svelte';
-	import type { Release } from '$lib/types';
+	import type { ReleaseHydrated } from '$lib/types';
 
-	let { data }: { data: { releases: Release[] } } = $props();
+	let { data }: { data: { releases: ReleaseHydrated[] } } = $props();
 </script>
 
 <svelte:head>

--- a/app/src/routes/releases/[slug]/+page.server.ts
+++ b/app/src/routes/releases/[slug]/+page.server.ts
@@ -1,8 +1,7 @@
-import { pinata } from '$lib/server/pinata';
-import type { ArtistManifest, Release } from '$lib/types/index.js';
+import type { ReleaseHydrated } from '$lib/types/index.js';
 
 export const load = async ({ fetch, params }) => {
-	const releases: Release[] = await fetch('/api/releases').then((res) => res.json());
+	const releases: ReleaseHydrated[] = await fetch('/api/releases').then((res) => res.json());
 
 	const matchingRelease = releases.find((release) => release.id === params.slug);
 
@@ -13,37 +12,7 @@ export const load = async ({ fetch, params }) => {
 		};
 	}
 
-	const artistManifests: ArtistManifest[] = await fetch(`/api/artists`).then((res) => res.json());
-
-	const artistManifest = artistManifests.find(
-		(manifest) => manifest.artist.name === matchingRelease.artistName
-	);
-
-	if (!artistManifest) {
-		return {
-			status: 404,
-			error: new Error('Artist Not Found')
-		};
-	}
-
-	const coverLink = await pinata.gateways.public.convert(matchingRelease.cover_cid);
-	const tracksWithLinks = await Promise.all(
-		matchingRelease.tracks.map(async (track) => {
-			const url = await pinata.gateways.public.convert(track.cid);
-			return {
-				...track,
-				url
-			};
-		})
-	);
-	const releaseWithLinks = {
-		...matchingRelease,
-		coverLink,
-		tracks: tracksWithLinks
-	};
-
 	return {
-		release: releaseWithLinks,
-		artistManifest
+		release: matchingRelease
 	};
 };

--- a/app/src/routes/releases/[slug]/+page.svelte
+++ b/app/src/routes/releases/[slug]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import type { ArtistManifest, Release, UserProfile } from '$lib/types';
-	import { prettifyDuration } from '$lib/utils';
+	import type { ArtistRaw, ReleaseHydrated, UserProfile } from '$lib/types';
+	import { makeImageLink, prettifyDuration } from '$lib/utils';
 	import { setActiveSong, userState } from '$lib/global/state.svelte';
 	import type { Session } from '@supabase/supabase-js';
 
@@ -8,23 +8,31 @@
 		data
 	}: {
 		data: {
-			release: Release;
-			artistManifest: ArtistManifest;
+			release: ReleaseHydrated;
 			profileData: UserProfile;
 			session: Session;
 		};
 	} = $props();
 
 	const release = data.release;
-	const artist = data.artistManifest;
+
+	const formatReleaseType = (type: string) => {
+		switch (type) {
+			case 'single':
+				return 'Single';
+			case 'album':
+				return 'Album';
+			case 'ep':
+				return 'EP';
+			default:
+				return type;
+		}
+	};
 </script>
 
 <svelte:head>
 	<title>{release.title} · Releases · Soli</title>
-	<meta
-		name="description"
-		content={`The release page for ${release.title} by ${release.artistName}.`}
-	/>
+	<meta name="description" content={`The release page for ${release.title} by ${release.title}.`} />
 </svelte:head>
 
 <small>Releases</small>
@@ -32,16 +40,18 @@
 <h2>{release.title}</h2>
 
 <div>
-	<a href={`/artists/${artist.artist.id}`}>{release.artistName}</a>
+	<a href={`/artists/${release.artist_id}`}>{release.artist_name}</a>
 </div>
 
 <div>
-	{release.type} released {new Date(release.release_date).toLocaleDateString()}
+	{formatReleaseType(release.release_type)} released {new Date(
+		release.release_date
+	).toLocaleDateString()}
 </div>
 
 <img
-	src={release.coverLink}
-	alt={`Cover art for '${release.title}' by ${release.artistName}'`}
+	src={makeImageLink(release.artwork_ipfs_cid)}
+	alt={`Cover art for '${release.title}' by ${release.artist_name}'`}
 	class="cover-art"
 />
 
@@ -58,8 +68,8 @@
 		{#each release.tracks as track, i}
 			<tr>
 				<td>{i + 1}</td>
-				<td>{track.name}</td>
-				<td>{prettifyDuration(track.duration_in_seconds)}</td>
+				<td>{track.title}</td>
+				<td>{prettifyDuration(track.duration_seconds)}</td>
 				<td>
 					{#if userState.liveBalance}
 						<button
@@ -67,13 +77,16 @@
 							onclick={() =>
 								setActiveSong(
 									track,
-									artist,
+									{
+										artistId: release.artist_id,
+										artistName: release.artist_name
+									},
 									data.session.user.id,
 									userState.liveBalance ?? data.profileData.tokens_balance,
 									data.profileData.pay_per_stream
 								)}
 						>
-							{#if track.cid === userState.activeSong?.cid}
+							{#if track.ipfs_cid === userState.activeSong?.ipfs_cid}
 								<span>Playing</span>
 							{:else}
 								<span>Play</span>
@@ -90,6 +103,10 @@
 	</tbody>
 </table>
 
+{#each release.tags as tag}
+	<div class="tag">{tag}</div>
+{/each}
+
 <style>
 	.cover-art {
 		aspect-ratio: 1/1;
@@ -99,5 +116,13 @@
 		width: 100%;
 		border-collapse: collapse;
 		text-align: left;
+	}
+	.tag {
+		display: inline-block;
+		background-color: lightgray;
+		color: #333;
+		padding: 0 0.5rem;
+		margin: 0.5rem 0;
+		border-radius: 4px;
 	}
 </style>


### PR DESCRIPTION
This adjusts the way Soli interacts with Supabase and IPFS/Pinata, with the app refactored accordingly. With this approach things are basically split as follows:

- Supabase: User data, music metadata, stream logs
- IPFS: Music, artwork, and photography

In effect, data lives in the former and content lives in the latter, at least for now. This feels like a sensible approach, though I'd like to mirror more stuff in IPFS further down the line.

In Supabase land there is now a healthy bundle of interrelated tables - users, artists, tracks, releases, etc. - with [Postgres Views](https://supabase.com/blog/postgresql-views) providing a handy way of serving hydrated data directly to the app.

This feels like a sensible approach, though I'd like to mirror more stuff in IPFS further down the line.

I've also taken the opportunity to refactor how IPFS audio files are fetched. Images are public so they can just be a fill-in-the-blank link, but audio files are now private and behind an auth check. I've arbitrarily picked a 5-second window in which the file can be accessed.

No doubt this approach is as full of holes as Swiss cheese, but it feels like a step in the right direction. 
