### PR TITLE
Layout improvements

### DIFF
--- a/app/src/lib/components/ArtistCard.svelte
+++ b/app/src/lib/components/ArtistCard.svelte
@@ -11,20 +11,23 @@
 </script>
 
 <a href={link}>
-	<div class="artist-circle">
-		{#if image}
-			<img src={image} alt={`Image of ${name}`} />
-		{:else}
-			<img src="/person-placeholder.png" alt="Placeholder person" />
-		{/if}
+	<div class="artist-card">
+		<div class="artist-circle">
+			{#if image}
+				<img src={image} alt={`Image of ${name}`} />
+			{:else}
+				<img src="/person-placeholder.png" alt="Placeholder person" />
+			{/if}
+		</div>
+		<div class="artist-name">{name}</div>
 	</div>
-	<div class="artist-name">{name}</div>
 </a>
 
 <style>
+	.artist-card {
+		max-width: 150px;
+	}
 	.artist-circle {
-		width: 100px;
-		height: 100px;
 		border-radius: 50%;
 		border: solid 2px lightgray;
 		margin-bottom: 0.2rem;
@@ -37,6 +40,8 @@
 	img {
 		width: 100%;
 		height: 100%;
+		background-color: lightgray;
+		aspect-ratio: 1;
 		border-radius: 50%;
 		z-index: 0;
 	}

--- a/app/src/lib/components/ArtistCardGrid.svelte
+++ b/app/src/lib/components/ArtistCardGrid.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import type { ArtistRaw } from '$lib/types';
+	import { makeImageLink } from '$lib/utils';
+	import ArtistCard from './ArtistCard.svelte';
+
+	let {
+		artists
+	}: {
+		artists: ArtistRaw[];
+	} = $props();
+</script>
+
+<div class="releases-grid">
+	{#each artists as artist}
+		<ArtistCard
+			link={`/artists/${artist.id}`}
+			name={artist.name}
+			image={artist.image_ipfs_cid
+				? makeImageLink(artist.image_ipfs_cid, 200)
+				: '/person-placeholder.png'}
+		/>
+	{/each}
+</div>
+
+<style>
+	.releases-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+		gap: 10px;
+	}
+</style>

--- a/app/src/lib/components/ReleaseCard.svelte
+++ b/app/src/lib/components/ReleaseCard.svelte
@@ -40,8 +40,6 @@
 	}
 	img {
 		aspect-ratio: 1;
-		width: 100px;
-		height: 100px;
 		border-radius: 10px;
 		margin-bottom: 0.5rem;
 		border: solid 2px lightgray;

--- a/app/src/lib/components/ReleaseCardGrid.svelte
+++ b/app/src/lib/components/ReleaseCardGrid.svelte
@@ -18,7 +18,7 @@
 			link={`/releases/${release.id}`}
 			name={release.title}
 			artist={release.artist_name}
-			coverArt={makeImageLink(release.artwork_ipfs_cid)}
+			coverArt={makeImageLink(release.artwork_ipfs_cid, 200)}
 			hideArtist={hideArtistName}
 		/>
 	{/each}
@@ -26,8 +26,8 @@
 
 <style>
 	.releases-grid {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 10px;
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+		gap: 20px;
 	}
 </style>

--- a/app/src/lib/utils/index.ts
+++ b/app/src/lib/utils/index.ts
@@ -16,6 +16,6 @@ export const prettifyPennies = (pence: number) => {
 	return `£${pounds}.${pennies < 10 ? '0' : ''}${pennies}`;
 };
 
-export const makeImageLink = (cid: string) => {
-	return 'https://' + PUBLIC_GATEWAY_URL + '/ipfs/' + cid;
+export const makeImageLink = (cid: string, width: number) => {
+	return `https://${PUBLIC_GATEWAY_URL}/ipfs/${cid}?img-width=${width}`;
 };

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import ArtistCard from '$lib/components/ArtistCard.svelte';
+	import ArtistCardGrid from '$lib/components/ArtistCardGrid.svelte';
 	import ReleaseCardGrid from '$lib/components/ReleaseCardGrid.svelte';
-	import { makeImageLink } from '$lib/utils';
 	import type { PageProps } from './$types';
 
 	let { data }: PageProps = $props();
@@ -21,26 +20,11 @@
 <section>
 	<a href="/artists"><h2>Artists</h2></a>
 
-	<div class="artists-container">
-		{#each data.artists as artist}
-			<ArtistCard
-				link={`/artists/${artist.id}`}
-				name={artist.name}
-				image={artist.image_ipfs_cid
-					? makeImageLink(artist.image_ipfs_cid)
-					: '/person-placeholder.png'}
-			/>
-		{/each}
-	</div>
+	<ArtistCardGrid artists={data.artists} />
 </section>
 
 <style>
 	section {
 		margin-bottom: 2rem;
-	}
-	.artists-container {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 10px;
 	}
 </style>

--- a/app/src/routes/api/artists/+server.ts
+++ b/app/src/routes/api/artists/+server.ts
@@ -17,5 +17,12 @@ export async function GET() {
 		return json({ error: 'Failed to fetch artist data' }, { status: 500 });
 	}
 
+	// Sort artists by name
+	data.sort((a, b) => {
+		if (a.name < b.name) return -1;
+		if (a.name > b.name) return 1;
+		return 0;
+	});
+
 	return json(data);
 }

--- a/app/src/routes/artists/+page.svelte
+++ b/app/src/routes/artists/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-	import ArtistCard from '$lib/components/ArtistCard.svelte';
-	import { makeImageLink } from '$lib/utils';
+	import ArtistCardGrid from '$lib/components/ArtistCardGrid.svelte';
 
 	let { data } = $props();
 </script>
@@ -12,22 +11,8 @@
 
 <h2>Artists</h2>
 
-<div class="artists-container">
-	{#each data.artists as artist}
-		<ArtistCard
-			link={`/artists/${artist.id}`}
-			name={artist.name}
-			image={artist.image_ipfs_cid
-				? makeImageLink(artist.image_ipfs_cid)
-				: '/person-placeholder.png'}
-		/>
-	{/each}
-</div>
-
-<style>
-	.artists-container {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 10px;
-	}
-</style>
+{#if data.artists.length === 0}
+	<p>No artists found.</p>
+{:else}
+	<ArtistCardGrid artists={data.artists} />
+{/if}

--- a/app/src/routes/artists/[slug]/+page.svelte
+++ b/app/src/routes/artists/[slug]/+page.svelte
@@ -17,59 +17,101 @@
 	<meta name="description" content={`The artist page for ${name}.`} />
 </svelte:head>
 
-<small>Artists</small>
+<div class="section-link">
+	> <a href="/artists">Artists</a>
+</div>
 
-<h2>{name}</h2>
+<div class="container">
+	<div class="artist-summary-card">
+		<h2>{name}</h2>
 
-{#if image_ipfs_cid}
-	<img src={makeImageLink(image_ipfs_cid)} alt={`Image of ${name}`} />
-{/if}
+		{#if image_ipfs_cid}
+			<img src={makeImageLink(image_ipfs_cid, 500)} alt={`Image of ${name}`} />
+		{/if}
 
-<div>{bio}</div>
+		<div>{bio}</div>
 
-{#if data.artist.website_url}
-	<a href={website_url}>{website_url?.replace('https://', '').replaceAll('/', '')}</a>
-{/if}
+		{#if data.artist.website_url}
+			<a href={website_url}>{website_url?.replace('https://', '').replaceAll('/', '')}</a>
+		{/if}
+	</div>
 
-<h3>Music</h3>
+	<div class="artist-music">
+		<h3>Music</h3>
 
-<!-- TODO: Sort by type (LP, EP, Single) and release date -->
+		<!-- TODO: Sort by type (LP, EP, Single) and release date -->
 
-{#if lps.length > 0}
-	<h4>LPs</h4>
-	<ReleaseCardGrid
-		releases={lps.map((lp) => {
-			return {
-				...lp,
-				artistName: name
-			};
-		})}
-		hideArtistName
-	/>
-{/if}
+		{#if lps.length > 0}
+			<h4>LPs</h4>
+			<ReleaseCardGrid
+				releases={lps.map((lp) => {
+					return {
+						...lp,
+						artistName: name
+					};
+				})}
+				hideArtistName
+			/>
+		{/if}
 
-{#if eps.length > 0}
-	<h4>EPs</h4>
-	<ReleaseCardGrid
-		releases={eps.map((ep) => {
-			return {
-				...ep,
-				artistName: name
-			};
-		})}
-		hideArtistName
-	/>
-{/if}
+		{#if eps.length > 0}
+			<h4>EPs</h4>
+			<ReleaseCardGrid
+				releases={eps.map((ep) => {
+					return {
+						...ep,
+						artistName: name
+					};
+				})}
+				hideArtistName
+			/>
+		{/if}
 
-{#if singles.length > 0}
-	<h4>Singles</h4>
-	<ReleaseCardGrid
-		releases={singles.map((single) => {
-			return {
-				...single,
-				artistName: name
-			};
-		})}
-		hideArtistName
-	/>
-{/if}
+		{#if singles.length > 0}
+			<h4>Singles</h4>
+			<ReleaseCardGrid
+				releases={singles.map((single) => {
+					return {
+						...single,
+						artistName: name
+					};
+				})}
+				hideArtistName
+			/>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.section-link {
+		margin-bottom: 1rem;
+	}
+	.container {
+		display: flex;
+		flex-direction: column;
+		gap: 1.5rem;
+		@media (min-width: 600px) {
+			flex-direction: row;
+		}
+	}
+	h2,
+	h3 {
+		margin: 0;
+		padding: 0;
+	}
+	.artist-summary-card {
+		max-width: 500px;
+		line-height: 1.2;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.artist-summary-card img {
+		aspect-ratio: 1;
+		background-color: lightgray;
+		border-radius: 10px;
+		margin-bottom: 0.5rem;
+		border: solid 2px lightgray;
+	}
+</style>

--- a/app/src/routes/releases/[slug]/+page.svelte
+++ b/app/src/routes/releases/[slug]/+page.svelte
@@ -140,6 +140,9 @@
 		border-collapse: collapse;
 		text-align: left;
 	}
+	th {
+		font-weight: 500;
+	}
 	tr {
 		border-bottom: 1px solid lightgray;
 	}

--- a/app/src/routes/releases/[slug]/+page.svelte
+++ b/app/src/routes/releases/[slug]/+page.svelte
@@ -35,79 +35,102 @@
 	<meta name="description" content={`The release page for ${release.title} by ${release.title}.`} />
 </svelte:head>
 
-<small>Releases</small>
-
-<h2>{release.title}</h2>
-
-<div>
-	<a href={`/artists/${release.artist_id}`}>{release.artist_name}</a>
+<div class="section-link">
+	> <a href="/artists">Releases</a>
 </div>
 
-<div>
-	{formatReleaseType(release.release_type)} released {new Date(
-		release.release_date
-	).toLocaleDateString()}
-</div>
+<div class="release-summary-card">
+	<div>
+		<h2>{release.title}</h2>
 
-<img
-	src={makeImageLink(release.artwork_ipfs_cid)}
-	alt={`Cover art for '${release.title}' by ${release.artist_name}'`}
-	class="cover-art"
-/>
+		<div>
+			<a href={`/artists/${release.artist_id}`}>{release.artist_name}</a>
+		</div>
+	</div>
 
-<table>
-	<thead>
-		<tr>
-			<th></th>
-			<th>Track</th>
-			<th>Duration</th>
-			<th></th>
-		</tr>
-	</thead>
-	<tbody>
-		{#each release.tracks as track, i}
+	<img
+		src={makeImageLink(release.artwork_ipfs_cid, 500)}
+		alt={`Cover art for '${release.title}' by ${release.artist_name}'`}
+		class="cover-art"
+	/>
+
+	<table>
+		<thead>
 			<tr>
-				<td>{i + 1}</td>
-				<td>{track.title}</td>
-				<td>{prettifyDuration(track.duration_seconds)}</td>
-				<td>
-					{#if userState.liveBalance}
-						<button
-							class="play-button"
-							onclick={() =>
-								setActiveSong(
-									track,
-									{
-										artistId: release.artist_id,
-										artistName: release.artist_name
-									},
-									data.session.user.id,
-									userState.liveBalance ?? data.profileData.tokens_balance,
-									data.profileData.pay_per_stream
-								)}
-						>
-							{#if track.ipfs_cid === userState.activeSong?.ipfs_cid}
-								<span>Playing</span>
-							{:else}
-								<span>Play</span>
-							{/if}
-						</button>
-					{:else}
-						<button class="play-button" disabled>
-							<span>Play</span>
-						</button>
-					{/if}
-				</td>
+				<th>#</th>
+				<th>Track</th>
+				<th>Duration</th>
+				<th></th>
 			</tr>
-		{/each}
-	</tbody>
-</table>
+		</thead>
+		<tbody>
+			{#each release.tracks as track, i}
+				<tr>
+					<td>{i + 1}</td>
+					<td>{track.title}</td>
+					<td>{prettifyDuration(track.duration_seconds)}</td>
+					<td>
+						{#if userState.liveBalance}
+							<button
+								class="play-button"
+								onclick={() =>
+									setActiveSong(
+										track,
+										{
+											artistId: release.artist_id,
+											artistName: release.artist_name
+										},
+										data.session.user.id,
+										userState.liveBalance ?? data.profileData.tokens_balance,
+										data.profileData.pay_per_stream
+									)}
+							>
+								{#if track.ipfs_cid === userState.activeSong?.ipfs_cid}
+									<span>Playing</span>
+								{:else}
+									<span>Play</span>
+								{/if}
+							</button>
+						{:else}
+							<button class="play-button" disabled>
+								<span>Play</span>
+							</button>
+						{/if}
+					</td>
+				</tr>
+			{/each}
+		</tbody>
+	</table>
 
-{#each release.tags as tag}
-	<div class="tag">{tag}</div>
-{/each}
+	<hr />
+
+	<div>
+		<div>
+			{formatReleaseType(release.release_type)} released {new Date(
+				release.release_date
+			).toLocaleDateString()}
+		</div>
+
+		{#each release.tags as tag}
+			<div class="tag">{tag}</div>
+		{/each}
+	</div>
+</div>
 
 <style>
+	.section-link {
+		margin-bottom: 1rem;
+	}
+	.release-summary-card {
+		max-width: 600px;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+	h2 {
+		margin: 0;
+		line-height: 1;
+	}
 	.cover-art {
 		aspect-ratio: 1/1;
 		background-color: lightgray;
@@ -117,6 +140,12 @@
 		border-collapse: collapse;
 		text-align: left;
 	}
+	tr {
+		border-bottom: 1px solid lightgray;
+	}
+	tr:last-child {
+		border-bottom: none;
+	}
 	.tag {
 		display: inline-block;
 		background-color: lightgray;
@@ -124,5 +153,6 @@
 		padding: 0 0.5rem;
 		margin: 0.5rem 0;
 		border-radius: 4px;
+		width: fit-content;
 	}
 </style>


### PR DESCRIPTION
Some modest tweaks to how artist and release pages look mostly, while also making the grids that appear in the directory pages a bit more flexible and generic.

| Before    | After |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/6a22c529-d77c-48be-813e-97a4b4c1bd0a) | ![image](https://github.com/user-attachments/assets/708c851a-7ef0-4c61-a1cf-b9c7dfa8d198)    |
| ![image](https://github.com/user-attachments/assets/ee9792e5-c993-4633-9041-227fb0504b5f) | ![image](https://github.com/user-attachments/assets/f4431216-e5e4-438c-9c99-76fae9719c80) |

There are more pressing things to be looking at but no harm in polishing as I go.