### PR TITLE
Richer nav

### DIFF
--- a/app/src/lib/components/icons/Cross.svelte
+++ b/app/src/lib/components/icons/Cross.svelte
@@ -1,0 +1,16 @@
+<svg
+	width="36px"
+	height="36px"
+	stroke-width="3"
+	viewBox="0 0 24 24"
+	fill="none"
+	xmlns="http://www.w3.org/2000/svg"
+	color="currentColor"
+	><path
+		d="M6.75827 17.2426L12.0009 12M17.2435 6.75736L12.0009 12M12.0009 12L6.75827 6.75736M12.0009 12L17.2435 17.2426"
+		stroke="currentColor"
+		stroke-width="3"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+	></path></svg
+>

--- a/app/src/lib/components/icons/Menu.svelte
+++ b/app/src/lib/components/icons/Menu.svelte
@@ -1,0 +1,20 @@
+<svg stroke-width="3" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"
+	><path d="M3 5H21" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"></path><path
+		d="M3 12H21"
+		stroke-width="3"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+	></path><path d="M3 19H21" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"
+	></path></svg
+>
+
+<style>
+	svg {
+		width: 30px;
+		height: 30px;
+		color: var(--color-accent);
+	}
+	path {
+		stroke: currentColor;
+	}
+</style>

--- a/app/src/lib/components/icons/Pause.svelte
+++ b/app/src/lib/components/icons/Pause.svelte
@@ -4,20 +4,20 @@
 	viewBox="0 0 24 24"
 	fill="none"
 	xmlns="http://www.w3.org/2000/svg"
-	color="#000000"
+	color="currentColor"
 	stroke-width="1.5"
 >
 	<path
 		d="M6 18.4V5.6C6 5.26863 6.26863 5 6.6 5H9.4C9.73137 5 10 5.26863 10 5.6V18.4C10 18.7314 9.73137 19 9.4 19H6.6C6.26863 19 6 18.7314 6 18.4Z"
-		fill="#000000"
-		stroke="#000000"
+		fill="currentColor"
+		stroke="currentColor"
 		stroke-width="1.5"
 	>
 	</path>
 	<path
 		d="M14 18.4V5.6C14 5.26863 14.2686 5 14.6 5H17.4C17.7314 5 18 5.26863 18 5.6V18.4C18 18.7314 17.7314 19 17.4 19H14.6C14.2686 19 14 18.7314 14 18.4Z"
-		fill="#000000"
-		stroke="#000000"
+		fill="currentColor"
+		stroke="currentColor"
 		stroke-width="1.5"
 	></path>
 </svg>

--- a/app/src/lib/components/icons/Play.svelte
+++ b/app/src/lib/components/icons/Play.svelte
@@ -4,13 +4,13 @@
 	viewBox="0 0 24 24"
 	fill="none"
 	xmlns="http://www.w3.org/2000/svg"
-	color="#000000"
+	color="currentColor"
 	stroke-width="1.5"
 >
 	<path
 		d="M6.90588 4.53682C6.50592 4.2998 6 4.58808 6 5.05299V18.947C6 19.4119 6.50592 19.7002 6.90588 19.4632L18.629 12.5162C19.0211 12.2838 19.0211 11.7162 18.629 11.4838L6.90588 4.53682Z"
-		fill="#000000"
-		stroke="#000000"
+		fill="currentColor"
+		stroke="currentColor"
 		stroke-width="1.5"
 		stroke-linecap="round"
 		stroke-linejoin="round"

--- a/app/src/lib/components/icons/Search.svelte
+++ b/app/src/lib/components/icons/Search.svelte
@@ -1,0 +1,21 @@
+<svg viewBox="0 0 24 24" stroke-width="3" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<path d="M17 17L21 21" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"> </path>
+	<path
+		d="M3 11C3 15.4183 6.58172 19 11 19C13.213 19 15.2161 18.1015 16.6644 16.6493C18.1077 15.2022 19 13.2053 19 11C19 6.58172 15.4183 3 11 3C6.58172 3 3 6.58172 3 11Z"
+		stroke-width="3"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+	>
+	</path>
+</svg>
+
+<style>
+	svg {
+		width: 30px;
+		height: 30px;
+		color: var(--color-accent);
+	}
+	path {
+		stroke: currentColor;
+	}
+</style>

--- a/app/src/lib/components/layout/ButtonWrapper.svelte
+++ b/app/src/lib/components/layout/ButtonWrapper.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	let { children, onClickFunction }: { children: Snippet; onClickFunction: () => void } = $props();
+</script>
+
+<div
+	onclick={onClickFunction}
+	onkeydown={(e) => {
+		if (e.key === 'Enter' || e.key === ' ') {
+			onClickFunction;
+		}
+	}}
+	role="button"
+	tabindex="0"
+>
+	{@render children()}
+</div>

--- a/app/src/lib/components/layout/ButtonWrapper.svelte
+++ b/app/src/lib/components/layout/ButtonWrapper.svelte
@@ -4,6 +4,7 @@
 </script>
 
 <div
+	class="button-wrapper"
 	onclick={onClickFunction}
 	onkeydown={(e) => {
 		if (e.key === 'Enter' || e.key === ' ') {
@@ -15,3 +16,14 @@
 >
 	{@render children()}
 </div>
+
+<style>
+	.button-wrapper {
+		display: flex;
+		justify-content: right;
+	}
+	.button-wrapper:hover {
+		cursor: pointer;
+		opacity: 0.8;
+	}
+</style>

--- a/app/src/lib/components/layout/Header.svelte
+++ b/app/src/lib/components/layout/Header.svelte
@@ -1,25 +1,40 @@
-<script>
-	let { userIsLoggedIn } = $props();
+<script lang="ts">
+	import Menu from '../icons/Menu.svelte';
+	import Search from '../icons/Search.svelte';
+	import ButtonWrapper from './ButtonWrapper.svelte';
+
+	let menuIsOpen = $state(false);
+	let searchIsOpen = $state(false);
 </script>
 
 <header>
-	<div class="section"></div>
-	<div class="section">
-		<a href="/" class="logo">
-			<img src="/full-logo-white.png" class="icon dark" alt="Soli emblem" />
-			<img src="/full-logo-black.png" class="icon light" alt="Soli emblem" />
-		</a>
-	</div>
-	<div class="section">
-		<div>
-			{#if userIsLoggedIn}
-				<a href="/account">Account</a>
-			{:else}
-				<a href="/login">Log in</a>
-			{/if}
-		</div>
-	</div>
+	<ButtonWrapper onClickFunction={() => (searchIsOpen = !searchIsOpen)}>
+		<Search />
+	</ButtonWrapper>
+	<a href="/">
+		<img src="/full-logo-white.png" class="icon dark" alt="Soli emblem" />
+		<img src="/full-logo-black.png" class="icon light" alt="Soli emblem" />
+	</a>
+	<ButtonWrapper onClickFunction={() => (menuIsOpen = !menuIsOpen)}>
+		<Menu />
+	</ButtonWrapper>
 </header>
+
+{#if menuIsOpen}
+	<nav class="menu">
+		<ul>
+			<li><a href="/about">Playlists</a></li>
+			<li><a href="/">Collections</a></li>
+			<li><a href="/account">Account</a></li>
+		</ul>
+	</nav>
+{/if}
+
+{#if searchIsOpen}
+	<div class="search-container">
+		<input type="text" placeholder="Search..." />
+	</div>
+{/if}
 
 <style>
 	header {
@@ -27,26 +42,26 @@
 		justify-content: space-between;
 		align-items: center;
 		margin: 1rem;
+		max-height: 60px;
 		a {
 			text-decoration: none;
 			color: inherit;
 		}
 	}
-	.section {
-		flex: 1;
-		display: flex;
-		justify-content: center;
-	}
-
-	.section:first-child > div {
-		margin-right: auto;
-	}
-
-	.section:last-child > div {
-		margin-left: auto;
-	}
 	.icon {
 		height: 50px;
+	}
+	input {
+		width: 90%;
+		max-width: 400px;
+		padding: 0.5rem;
+		margin: 0 1rem;
+		border: 1px solid var(--color-accent);
+		border-radius: 4px;
+		font-size: 1rem;
+	}
+	.search-container {
+		width: 100%;
 	}
 	@media (min-width: 600px) {
 		.icon:hover {

--- a/app/src/lib/components/layout/Header.svelte
+++ b/app/src/lib/components/layout/Header.svelte
@@ -1,40 +1,41 @@
 <script lang="ts">
 	import Menu from '../icons/Menu.svelte';
+	import Cross from '../icons/Cross.svelte';
 	import Search from '../icons/Search.svelte';
 	import ButtonWrapper from './ButtonWrapper.svelte';
 
-	let menuIsOpen = $state(false);
+	let {
+		menuIsOpen = $bindable()
+	}: {
+		menuIsOpen: boolean;
+	} = $props();
+
 	let searchIsOpen = $state(false);
 </script>
 
 <header>
-	<ButtonWrapper onClickFunction={() => (searchIsOpen = !searchIsOpen)}>
+	<!-- <ButtonWrapper onClickFunction={() => (searchIsOpen = !searchIsOpen)}>
 		<Search />
-	</ButtonWrapper>
+	</ButtonWrapper> -->
+	<div style="width: 30px;"></div>
 	<a href="/">
 		<img src="/full-logo-white.png" class="icon dark" alt="Soli emblem" />
 		<img src="/full-logo-black.png" class="icon light" alt="Soli emblem" />
 	</a>
 	<ButtonWrapper onClickFunction={() => (menuIsOpen = !menuIsOpen)}>
-		<Menu />
+		{#if menuIsOpen}
+			<Cross />
+		{:else}
+			<Menu />
+		{/if}
 	</ButtonWrapper>
 </header>
 
-{#if menuIsOpen}
-	<nav class="menu">
-		<ul>
-			<li><a href="/about">Playlists</a></li>
-			<li><a href="/">Collections</a></li>
-			<li><a href="/account">Account</a></li>
-		</ul>
-	</nav>
-{/if}
-
-{#if searchIsOpen}
+<!-- {#if searchIsOpen}
 	<div class="search-container">
 		<input type="text" placeholder="Search..." />
 	</div>
-{/if}
+{/if} -->
 
 <style>
 	header {

--- a/app/src/lib/components/releases/ReleaseTrackButton.svelte
+++ b/app/src/lib/components/releases/ReleaseTrackButton.svelte
@@ -4,6 +4,7 @@
 	import type { Session } from '@supabase/supabase-js';
 	import Pause from '../icons/Pause.svelte';
 	import Play from '../icons/Play.svelte';
+	import ButtonWrapper from '../layout/ButtonWrapper.svelte';
 
 	let {
 		track,
@@ -19,9 +20,8 @@
 </script>
 
 {#if userState.liveBalance}
-	<button
-		class="play-button"
-		onclick={() => {
+	<ButtonWrapper
+		onClickFunction={() => {
 			if (track.ipfs_cid == userState.activeSong?.ipfs_cid) {
 				userState.activeSongIsPaused = !userState.activeSongIsPaused;
 			} else {
@@ -37,13 +37,30 @@
 		}}
 	>
 		{#if track.ipfs_cid === userState.activeSong?.ipfs_cid && !userState.activeSongIsPaused}
-			<Pause />
+			<div class="play-button"><Pause /></div>
 		{:else}
-			<Play />
+			<div class="play-button"><Play /></div>
 		{/if}
-	</button>
+	</ButtonWrapper>
 {:else}
 	<button class="play-button" disabled>
 		<span>Play</span>
 	</button>
 {/if}
+
+<style>
+	button:hover {
+		cursor: pointer;
+	}
+	.play-button {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		padding: 10%;
+		border-radius: 50%;
+		background-color: var(--color-accent);
+		color: var(--color-background);
+	}
+</style>

--- a/app/src/lib/components/releases/ReleaseTracks.svelte
+++ b/app/src/lib/components/releases/ReleaseTracks.svelte
@@ -50,9 +50,4 @@
 	tr:not(:last-child) {
 		border-bottom: 1px solid gray;
 	}
-	.play-button-container {
-		display: flex;
-		justify-content: end;
-		align-items: center;
-	}
 </style>

--- a/app/src/routes/+layout.svelte
+++ b/app/src/routes/+layout.svelte
@@ -9,10 +9,11 @@
 	import Footer from '$lib/components/layout/Footer.svelte';
 	import AudioPlayer from '$lib/components/audio-player/AudioPlayer.svelte';
 
-	export let data;
+	let { children, data } = $props();
 
-	let { supabase, session } = data;
-	$: ({ supabase, session } = data);
+	let { supabase, session } = $state(data);
+
+	let menuIsOpen = $state(false);
 
 	onMount(() => {
 		const { data } = supabase.auth.onAuthStateChange((event, newSession) => {
@@ -22,6 +23,13 @@
 		});
 		return () => data.subscription.unsubscribe();
 	});
+
+	const menuLinks = [
+		{ href: '/account', label: 'Account' },
+		{ href: '/releases', label: 'Releases' },
+		{ href: '/artists', label: 'Artists' },
+		{ href: '/about', label: 'About' }
+	];
 </script>
 
 <svelte:head>
@@ -29,10 +37,27 @@
 	<meta name="theme-color" content="#f0f0f0" media="(prefers-color-scheme: light)" />
 </svelte:head>
 
-<Header userIsLoggedIn={session} />
+{#if menuIsOpen}
+	<div class="menu">
+		<Header bind:menuIsOpen />
+		<nav>
+			<ul>
+				{#if session}
+					{#each menuLinks as link}
+						<li><a href={link.href} onclick={() => (menuIsOpen = !menuIsOpen)}>{link.label}</a></li>
+					{/each}
+				{:else}
+					<li><a href="/login" onclick={() => (menuIsOpen = !menuIsOpen)}>Login</a></li>
+				{/if}
+			</ul>
+		</nav>
+	</div>
+{:else}
+	<Header bind:menuIsOpen />
+{/if}
 
 <main>
-	<slot />
+	{@render children()}
 </main>
 
 <Footer />
@@ -50,5 +75,27 @@
 <style>
 	main {
 		margin: 0 1rem;
+	}
+	.menu {
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 100vw;
+		height: 100vh;
+		background-color: var(--color-background);
+		z-index: 1000;
+	}
+	ul {
+		list-style: none;
+		padding: 1rem;
+		margin: 0;
+	}
+	li {
+		margin: 0.5rem 0;
+	}
+	a {
+		text-decoration: none;
+		color: var(--color-text);
+		font-size: 1.4rem;
 	}
 </style>

--- a/app/src/routes/releases/[slug]/+page.svelte
+++ b/app/src/routes/releases/[slug]/+page.svelte
@@ -4,6 +4,7 @@
 	import type { Session } from '@supabase/supabase-js';
 	import ReleaseTracks from '$lib/components/releases/ReleaseTracks.svelte';
 	import { setActiveSong, userState } from '$lib/global/state.svelte';
+	import ButtonWrapper from '$lib/components/layout/ButtonWrapper.svelte';
 
 	let {
 		data
@@ -46,8 +47,8 @@
 		class="cover-art"
 	/>
 
-	<button
-		onclick={() => {
+	<ButtonWrapper
+		onClickFunction={() => {
 			setActiveSong(
 				release.tracks[0],
 				release,
@@ -58,8 +59,10 @@
 			userState.autoPlay = true;
 		}}
 	>
-		Play full {releaseType === 'ep' ? 'EP' : releaseType}
-	</button>
+		<div class="play-full-release-button">
+			Play full {releaseType === 'ep' ? 'EP' : releaseType}
+		</div>
+	</ButtonWrapper>
 
 	<ReleaseTracks {release} profileData={data.profileData} session={data.session} />
 
@@ -106,7 +109,11 @@
 		border-radius: 4px;
 		width: fit-content;
 	}
-	button:hover {
-		cursor: pointer;
+	.play-full-release-button {
+		background-color: var(--color-accent);
+		color: var(--color-background);
+		width: 100%;
+		border-radius: 4px;
+		text-align: center;
 	}
 </style>


### PR DESCRIPTION
Introduces a basic expandable menu along with some styling refinements.

| Closed    | Open |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/dc7f35ee-561f-4d0b-b60e-058efb74cb4c)  | ![image](https://github.com/user-attachments/assets/211967a9-980a-4465-b4d5-a7c2ec506c34) |

Nothing fancy but opens the door to better browsing, plus I think the button tweaks make the release pages look a lot better.

I've added a `ButtonWrapper` component so that buttons and nav icons follow best practice for accessibility without having different platforms/operating systems using their own buttons styling.

There's some search UI groundwork commented out under the hood but implementation is best left to a separate PR.