### PR TITLE
Allow artists to access and use Dashboard

### DIFF
--- a/app/src/routes/+layout.ts
+++ b/app/src/routes/+layout.ts
@@ -1,8 +1,8 @@
-// src/routes/+layout.ts
 import { createBrowserClient, createServerClient, isBrowser } from '@supabase/ssr';
 import type { LayoutLoad } from './$types';
 import { userState } from '$lib/global/state.svelte';
 import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL } from '$lib/global/config';
+import { cookieOptions } from '../../../shared/utils/cookies';
 
 export const load: LayoutLoad = async ({ fetch, data, depends }) => {
 	depends('supabase:auth');
@@ -11,7 +11,8 @@ export const load: LayoutLoad = async ({ fetch, data, depends }) => {
 		? createBrowserClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
 				global: {
 					fetch
-				}
+				},
+				cookieOptions
 			})
 		: createServerClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
 				global: {
@@ -21,7 +22,8 @@ export const load: LayoutLoad = async ({ fetch, data, depends }) => {
 					getAll() {
 						return data.cookies;
 					}
-				}
+				},
+				cookieOptions
 			});
 
 	/**

--- a/app/src/routes/login/+page.server.ts
+++ b/app/src/routes/login/+page.server.ts
@@ -43,7 +43,12 @@ export const actions: Actions = {
 			});
 		}
 
-		const { error } = await supabase.auth.signInWithOtp({ email });
+		const { error } = await supabase.auth.signInWithOtp({
+			email,
+			options: {
+				emailRedirectTo: 'https://soli.network'
+			}
+		});
 
 		if (error) {
 			return fail(400, {

--- a/app/src/routes/login/+page.svelte
+++ b/app/src/routes/login/+page.svelte
@@ -1,4 +1,3 @@
-<!-- src/routes/+page.svelte -->
 <script lang="ts">
 	import { enhance } from '$app/forms';
 	import type { ActionData, SubmitFunction } from './$types.js';

--- a/dashboard/netlify.toml
+++ b/dashboard/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "npm run build"
+  publish = "build"

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -8,7 +8,8 @@
 			"name": "dashboard",
 			"version": "0.0.1",
 			"dependencies": {
-				"@supabase/supabase-js": "^2.52.1",
+				"@supabase/ssr": "^0.6.1",
+				"@supabase/supabase-js": "^2.54.0",
 				"music-metadata": "^11.7.3",
 				"pinata": "^2.4.9"
 			},
@@ -841,39 +842,59 @@
 			}
 		},
 		"node_modules/@supabase/realtime-js": {
-			"version": "2.11.15",
-			"resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.15.tgz",
-			"integrity": "sha512-HQKRnwAqdVqJW/P9TjKVK+/ETpW4yQ8tyDPPtRMKOH4Uh3vQD74vmj353CYs8+YwVBKubeUOOEpI9CT8mT4obw==",
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.0.tgz",
+			"integrity": "sha512-SEIWApsxyoAe68WU2/5PCCuBwa11LL4Bb8K3r2FHCt3ROpaTthmDiWEhnLMGayP05N4QeYrMk0kyTZOwid/Hjw==",
 			"license": "MIT",
 			"dependencies": {
 				"@supabase/node-fetch": "^2.6.13",
 				"@types/phoenix": "^1.6.6",
 				"@types/ws": "^8.18.1",
-				"isows": "^1.0.7",
 				"ws": "^8.18.2"
 			}
 		},
+		"node_modules/@supabase/ssr": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.6.1.tgz",
+			"integrity": "sha512-QtQgEMvaDzr77Mk3vZ3jWg2/y+D8tExYF7vcJT+wQ8ysuvOeGGjYbZlvj5bHYsj/SpC0bihcisnwPrM4Gp5G4g==",
+			"license": "MIT",
+			"dependencies": {
+				"cookie": "^1.0.1"
+			},
+			"peerDependencies": {
+				"@supabase/supabase-js": "^2.43.4"
+			}
+		},
+		"node_modules/@supabase/ssr/node_modules/cookie": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+			"integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@supabase/storage-js": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
-			"integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+			"version": "2.10.4",
+			"resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.10.4.tgz",
+			"integrity": "sha512-cvL02GarJVFcNoWe36VBybQqTVRq6wQSOCvTS64C+eyuxOruFIm1utZAY0xi2qKtHJO3EjKaj8iWJKySusDmAQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@supabase/node-fetch": "^2.6.14"
 			}
 		},
 		"node_modules/@supabase/supabase-js": {
-			"version": "2.52.1",
-			"resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.52.1.tgz",
-			"integrity": "sha512-IxYljprgl381j4SuFrW4JimjTb59WJ98DqxhMvEOJjpGJWuZ7kwttIWn7E4NBnvkYwZ948zJkJ7dSI6B0oO0Xw==",
+			"version": "2.54.0",
+			"resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.54.0.tgz",
+			"integrity": "sha512-DLw83YwBfAaFiL3oWV26+sHRdeCGtxmIKccjh/Pndze3BWM4fZghzYKhk3ElOQU8Bluq4AkkCJ5bM5Szl/sfRg==",
 			"license": "MIT",
 			"dependencies": {
 				"@supabase/auth-js": "2.71.1",
 				"@supabase/functions-js": "2.4.5",
 				"@supabase/node-fetch": "2.6.15",
 				"@supabase/postgrest-js": "1.19.4",
-				"@supabase/realtime-js": "2.11.15",
-				"@supabase/storage-js": "2.7.1"
+				"@supabase/realtime-js": "2.15.0",
+				"@supabase/storage-js": "^2.10.4"
 			}
 		},
 		"node_modules/@sveltejs/acorn-typescript": {
@@ -1282,21 +1303,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.6"
-			}
-		},
-		"node_modules/isows": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
-			"integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/wevm"
-				}
-			],
-			"license": "MIT",
-			"peerDependencies": {
-				"ws": "*"
 			}
 		},
 		"node_modules/kleur": {

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -14,7 +14,7 @@
 				"pinata": "^2.4.9"
 			},
 			"devDependencies": {
-				"@sveltejs/adapter-auto": "^6.0.1",
+				"@sveltejs/adapter-netlify": "^5.0.1",
 				"@sveltejs/kit": "^2.26.1",
 				"@sveltejs/vite-plugin-svelte": "^5.1.1",
 				"svelte": "^5.36.17",
@@ -462,6 +462,13 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@iarna/toml": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+			"integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.8",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
@@ -907,14 +914,19 @@
 				"acorn": "^8.9.0"
 			}
 		},
-		"node_modules/@sveltejs/adapter-auto": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-6.0.1.tgz",
-			"integrity": "sha512-mcWud3pYGPWM2Pphdj8G9Qiq24nZ8L4LB7coCUckUEy5Y7wOWGJ/enaZ4AtJTcSm5dNK1rIkBRoqt+ae4zlxcQ==",
+		"node_modules/@sveltejs/adapter-netlify": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-netlify/-/adapter-netlify-5.1.1.tgz",
+			"integrity": "sha512-VYiQydwks3aLBWeiHlxtVUbemE4J0qcjmeY7aQqThKlyi2Xb2s1wWvR/laMkMOZ0NpZwnazHmbmGae+1oA30Rw==",
 			"dev": true,
 			"license": "MIT",
+			"dependencies": {
+				"@iarna/toml": "^2.2.5",
+				"esbuild": "^0.25.4",
+				"set-cookie-parser": "^2.6.0"
+			},
 			"peerDependencies": {
-				"@sveltejs/kit": "^2.0.0"
+				"@sveltejs/kit": "^2.4.0"
 			}
 		},
 		"node_modules/@sveltejs/kit": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -12,7 +12,7 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-auto": "^6.0.1",
+		"@sveltejs/adapter-netlify": "^5.0.1",
 		"@sveltejs/kit": "^2.26.1",
 		"@sveltejs/vite-plugin-svelte": "^5.1.1",
 		"svelte": "^5.36.17",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -21,7 +21,8 @@
 		"vite": "^6.3.5"
 	},
 	"dependencies": {
-		"@supabase/supabase-js": "^2.52.1",
+		"@supabase/ssr": "^0.6.1",
+		"@supabase/supabase-js": "^2.54.0",
 		"music-metadata": "^11.7.3",
 		"pinata": "^2.4.9"
 	}

--- a/dashboard/src/app.d.ts
+++ b/dashboard/src/app.d.ts
@@ -1,13 +1,16 @@
-// See https://svelte.dev/docs/kit/types#app.d.ts
-// for information about these interfaces
-declare global {
-	namespace App {
-		// interface Error {}
-		// interface Locals {}
-		// interface PageData {}
-		// interface PageState {}
-		// interface Platform {}
-	}
-}
+import { SupabaseClient, Session } from "@supabase/supabase-js";
 
-export {};
+declare global {
+  namespace App {
+    interface Locals {
+      supabase: SupabaseClient;
+      safeGetSession(): Promise<{ session: Session | null; user: User | null }>;
+      session: Session | null;
+      user: User | null;
+    }
+    interface PageData {
+      session: Session | null;
+      user: User | null;
+    }
+  }
+}

--- a/dashboard/src/hooks.server.ts
+++ b/dashboard/src/hooks.server.ts
@@ -1,0 +1,58 @@
+import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL } from "$lib/config";
+import { createServerClient } from "@supabase/ssr";
+import { redirect, type Handle } from "@sveltejs/kit";
+import { sequence } from "@sveltejs/kit/hooks";
+
+export const supabase: Handle = async ({ event, resolve }) => {
+  event.locals.supabase = createServerClient(
+    PUBLIC_SUPABASE_URL,
+    PUBLIC_SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        getAll: () => event.cookies.getAll(),
+        setAll: (cookiesToSet) => {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            event.cookies.set(name, value, { ...options, path: "/" });
+          });
+        },
+      },
+    }
+  );
+  event.locals.safeGetSession = async () => {
+    const {
+      data: { session },
+    } = await event.locals.supabase.auth.getSession();
+    if (!session) {
+      return { session: null, user: null };
+    }
+
+    const {
+      data: { user },
+      error,
+    } = await event.locals.supabase.auth.getUser();
+    if (error) {
+      return { session: null, user: null };
+    }
+
+    return { session, user };
+  };
+
+  return resolve(event, {
+    filterSerializedResponseHeaders(name) {
+      return name === "content-range" || name === "x-supabase-api-version";
+    },
+  });
+};
+
+const authGuard: Handle = async ({ event, resolve }) => {
+  const { session, user } = await event.locals.safeGetSession();
+  event.locals.session = session;
+  event.locals.user = user;
+
+  if (!event.locals.session) {
+    redirect(303, "/login");
+  }
+  return resolve(event);
+};
+
+export const handle: Handle = sequence(supabase, authGuard);

--- a/dashboard/src/hooks.server.ts
+++ b/dashboard/src/hooks.server.ts
@@ -1,3 +1,4 @@
+import { dev } from "$app/environment";
 import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL } from "$lib/config";
 import { createServerClient } from "@supabase/ssr";
 import { redirect, type Handle } from "@sveltejs/kit";
@@ -51,7 +52,8 @@ const authGuard: Handle = async ({ event, resolve }) => {
 
   if (
     !event.locals.session &&
-    !["/login", "/auth"].some((path) => event.url.pathname.startsWith(path))
+    !["/login", "/auth"].some((path) => event.url.pathname.startsWith(path)) &&
+    !dev
   ) {
     redirect(303, "/login");
   }

--- a/dashboard/src/hooks.server.ts
+++ b/dashboard/src/hooks.server.ts
@@ -49,7 +49,10 @@ const authGuard: Handle = async ({ event, resolve }) => {
   event.locals.session = session;
   event.locals.user = user;
 
-  if (!event.locals.session) {
+  if (
+    !event.locals.session &&
+    !["/login", "/auth"].some((path) => event.url.pathname.startsWith(path))
+  ) {
     redirect(303, "/login");
   }
   return resolve(event);

--- a/dashboard/src/lib/components/Card.svelte
+++ b/dashboard/src/lib/components/Card.svelte
@@ -9,9 +9,17 @@
 </div>
 
 <style>
+  :root {
+    --card-background: #f9f9f9;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --card-background: #313131;
+    }
+  }
   .card {
-    color: var(--color-background);
-    background-color: var(--color-text);
+    color: var(--color-text);
+    background-color: var(--card-background);
     line-height: 1.1;
     padding: 0.5rem;
     margin: 0.5rem 0;

--- a/dashboard/src/lib/components/ProfileSummary.svelte
+++ b/dashboard/src/lib/components/ProfileSummary.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { makeImageLink } from "$lib/utils";
+  import type { ArtistRaw } from "../../../../shared/types";
+
+  let { activeArtist }: { activeArtist: ArtistRaw } = $props();
+</script>
+
+<div class="artist-profile">
+  <h2>Profile</h2>
+  {#if activeArtist.image_ipfs_cid}
+    <img
+      src={makeImageLink(activeArtist.image_ipfs_cid, 300)}
+      alt={activeArtist.name}
+    />
+  {:else}
+    <div>No profile image</div>
+  {/if}
+  <div>Name: {activeArtist.name}</div>
+  <div>Bio: {activeArtist.bio}</div>
+  <div>
+    Website: <a
+      href={activeArtist.website_url}
+      target="_blank"
+      rel="noopener noreferrer">{activeArtist.website_url}</a
+    >
+  </div>
+  <div>
+    Created At: {new Date(activeArtist.created_at).toLocaleDateString()}
+  </div>
+</div>
+
+<style>
+  .artist-profile {
+    width: 100%;
+  }
+</style>

--- a/dashboard/src/lib/components/ProfileSummary.svelte
+++ b/dashboard/src/lib/components/ProfileSummary.svelte
@@ -1,41 +1,55 @@
 <script lang="ts">
+  import { enhance } from "$app/forms";
   import { makeImageLink } from "$lib/utils";
   import type { ArtistRaw } from "../../../../shared/types";
 
   let { activeArtist }: { activeArtist: ArtistRaw } = $props();
+  let uploading = $state(false);
+
+  function handleUpload() {
+    uploading = true;
+    return async ({ update }: { update: () => Promise<void> }) => {
+      await update();
+      uploading = false;
+    };
+  }
 </script>
 
 <div class="artist-profile">
   <h2>Profile</h2>
-  {#if activeArtist.image_ipfs_cid}
-    <img
-      src={makeImageLink(activeArtist.image_ipfs_cid, 300)}
-      alt={activeArtist.name}
-    />
-  {:else}
-    <div>No profile image</div>
-  {/if}
-  <div>
-    <div><strong>Name:</strong> {activeArtist.name}</div>
-    <div><strong>Bio:</strong> {activeArtist.bio}</div>
-    <div>
-      <strong>Website:</strong>
-      <a
-        href={activeArtist.website_url}
-        target="_blank"
-        rel="noopener noreferrer">{activeArtist.website_url}</a
-      >
-    </div>
-  </div>
-  <button
-    class="edit-button"
-    onclick={() => {
-      // Logic to handle editing the profile
-      console.log("Edit profile clicked");
-    }}
+  <h3>{activeArtist.name}</h3>
+  <form
+    method="POST"
+    enctype="multipart/form-data"
+    action="?/updateArtistDetails"
+    use:enhance={handleUpload}
   >
-    Edit profile details
-  </button>
+    <input type="hidden" name="artistID" value={activeArtist.id} />
+    <input type="hidden" name="artistName" value={activeArtist.name} />
+    {#if activeArtist.image_ipfs_cid}
+      <img
+        src={makeImageLink(activeArtist.image_ipfs_cid, 300)}
+        alt={activeArtist.name}
+      />
+    {:else}
+      <div>No profile image</div>
+    {/if}
+    <label for="file">Change profile image</label>
+    <input type="file" id="file" name="artistImage" accept=".jpg,.jpeg,.png" />
+    <label for="artistBio">Bio</label>
+    <textarea name="artistBio" placeholder="Bio">{activeArtist.bio}</textarea>
+    <label for="artistWebsite">Website</label>
+    <input
+      type="text"
+      name="artistWebsite"
+      id="artistWebsite"
+      placeholder="Website URL"
+      value={activeArtist.website_url}
+    />
+    <button disabled={uploading} type="submit">
+      {uploading ? "Updating..." : "Update profile"}
+    </button>
+  </form>
 </div>
 
 <style>
@@ -45,5 +59,15 @@
     flex-direction: column;
     align-items: flex-start;
     gap: 1rem;
+  }
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    width: 100%;
+    max-width: 600px;
+  }
+  img {
+    max-width: 300px;
   }
 </style>

--- a/dashboard/src/lib/components/ProfileSummary.svelte
+++ b/dashboard/src/lib/components/ProfileSummary.svelte
@@ -15,22 +15,35 @@
   {:else}
     <div>No profile image</div>
   {/if}
-  <div>Name: {activeArtist.name}</div>
-  <div>Bio: {activeArtist.bio}</div>
   <div>
-    Website: <a
-      href={activeArtist.website_url}
-      target="_blank"
-      rel="noopener noreferrer">{activeArtist.website_url}</a
-    >
+    <div><strong>Name:</strong> {activeArtist.name}</div>
+    <div><strong>Bio:</strong> {activeArtist.bio}</div>
+    <div>
+      <strong>Website:</strong>
+      <a
+        href={activeArtist.website_url}
+        target="_blank"
+        rel="noopener noreferrer">{activeArtist.website_url}</a
+      >
+    </div>
   </div>
-  <div>
-    Created At: {new Date(activeArtist.created_at).toLocaleDateString()}
-  </div>
+  <button
+    class="edit-button"
+    onclick={() => {
+      // Logic to handle editing the profile
+      console.log("Edit profile clicked");
+    }}
+  >
+    Edit profile details
+  </button>
 </div>
 
 <style>
   .artist-profile {
     width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
   }
 </style>

--- a/dashboard/src/lib/components/ProfileSummary.svelte
+++ b/dashboard/src/lib/components/ProfileSummary.svelte
@@ -34,10 +34,23 @@
     {:else}
       <div>No profile image</div>
     {/if}
+    <input
+      type="hidden"
+      name="existingImageCID"
+      value={activeArtist.image_ipfs_cid}
+    />
     <label for="file">Change profile image</label>
-    <input type="file" id="file" name="artistImage" accept=".jpg,.jpeg,.png" />
+    <input
+      type="file"
+      id="file"
+      name="artistImageNew"
+      accept=".jpg,.jpeg,.png"
+      required={false}
+    />
     <label for="artistBio">Bio</label>
-    <textarea name="artistBio" placeholder="Bio">{activeArtist.bio}</textarea>
+    <textarea name="artistBio" placeholder="Bio" required={false}>
+      {activeArtist.bio}
+    </textarea>
     <label for="artistWebsite">Website</label>
     <input
       type="text"
@@ -45,6 +58,7 @@
       id="artistWebsite"
       placeholder="Website URL"
       value={activeArtist.website_url}
+      required={false}
     />
     <button disabled={uploading} type="submit">
       {uploading ? "Updating..." : "Update profile"}

--- a/dashboard/src/lib/components/ReleaseInfo.svelte
+++ b/dashboard/src/lib/components/ReleaseInfo.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
   import { makeImageLink } from "$lib/utils";
   import type { ReleaseHydrated } from "../../../../shared/types";
-  import {
-    formatReleaseType,
-    prettifyDuration,
-  } from "../../../../shared/utils";
+  import { formatReleaseType } from "../../../../shared/utils";
 
   const {
     release,
@@ -31,7 +28,6 @@
       {#each release.tracks as track}
         <li>
           {track.title}
-          <small>({prettifyDuration(track.duration_seconds)})</small>
         </li>
       {/each}
     </ol>
@@ -57,9 +53,5 @@
     width: 150px;
     aspect-ratio: 1 / 1;
     box-shadow: var(--box-shadow);
-  }
-  small {
-    font-weight: 500;
-    font-size: 70%;
   }
 </style>

--- a/dashboard/src/lib/state.svelte.ts
+++ b/dashboard/src/lib/state.svelte.ts
@@ -2,6 +2,10 @@ import type { ArtistRaw } from "../../../shared/types";
 
 export const dashboardState: {
   activeArtist: ArtistRaw | null;
+  activeSection: DashboardSectionId;
 } = $state({
   activeArtist: null,
+  activeSection: "profile",
 });
+
+export type DashboardSectionId = "profile" | "music" | "stats" | "payouts";

--- a/dashboard/src/routes/+layout.server.ts
+++ b/dashboard/src/routes/+layout.server.ts
@@ -8,8 +8,14 @@ import type {
   TrackRaw,
 } from "../../../shared/types";
 import { sortReleasesByDate } from "../../../shared/utils";
+import type { LayoutServerLoad } from "./$types";
 
-export const load = async () => {
+export const load: LayoutServerLoad = async ({
+  locals: { safeGetSession },
+  cookies,
+}) => {
+  const { session, user } = await safeGetSession();
+
   const {
     data: artists,
     error: artistsError,
@@ -91,6 +97,9 @@ export const load = async () => {
   }
 
   return {
+    session,
+    user,
+    cookies: cookies.getAll(),
     artists,
     releasesRaw,
     releasesHydrated: sortReleasesByDate(releasesHydrated),

--- a/dashboard/src/routes/+layout.server.ts
+++ b/dashboard/src/routes/+layout.server.ts
@@ -10,6 +10,7 @@ import type {
 import { sortReleasesByDate } from "../../../shared/utils";
 import type { LayoutServerLoad } from "./$types";
 import { POWER_USER_ID } from "$lib/config";
+import { dev } from "$app/environment";
 
 export const load: LayoutServerLoad = async ({
   locals: { safeGetSession },
@@ -17,7 +18,9 @@ export const load: LayoutServerLoad = async ({
 }) => {
   const { session, user } = await safeGetSession();
 
-  if (!session || !user) {
+  const userID = dev ? POWER_USER_ID : session?.user.id;
+
+  if (!session && !dev) {
     return {
       session,
       user,
@@ -39,7 +42,7 @@ export const load: LayoutServerLoad = async ({
   } = await supabase
     .from("artist_members")
     .select("artist_id")
-    .eq("user_id", session.user.id);
+    .eq("user_id", userID);
 
   if (userError || !userData) {
     console.error("Error fetching user data:", userError);
@@ -55,7 +58,7 @@ export const load: LayoutServerLoad = async ({
     data: ArtistRaw[] | null;
     error: Error | null;
   } =
-    session.user.id === POWER_USER_ID
+    userID === POWER_USER_ID
       ? await supabase.from("artists").select("*")
       : await supabase
           .from("artists")

--- a/dashboard/src/routes/+layout.server.ts
+++ b/dashboard/src/routes/+layout.server.ts
@@ -18,7 +18,16 @@ export const load: LayoutServerLoad = async ({
   const { session, user } = await safeGetSession();
 
   if (!session || !user) {
-    return fail(401, { error: "Unauthorized" });
+    return {
+      session,
+      user,
+      cookies: cookies.getAll(),
+      artists: [],
+      releasesRaw: [],
+      releasesHydrated: [],
+      songs: [],
+      streams: [],
+    };
   }
 
   const {

--- a/dashboard/src/routes/+layout.server.ts
+++ b/dashboard/src/routes/+layout.server.ts
@@ -4,6 +4,7 @@ import type {
   ArtistRaw,
   ReleaseHydrated,
   ReleaseRaw,
+  StreamLog,
   TrackRaw,
 } from "../../../shared/types";
 import { sortReleasesByDate } from "../../../shared/utils";
@@ -76,10 +77,24 @@ export const load = async () => {
     return 0;
   });
 
+  // Get all streams for the artist
+  const {
+    data: streams,
+    error: streamsError,
+  }: {
+    data: StreamLog[] | null; // Adjust type as needed
+    error: Error | null;
+  } = await supabase.from("streams").select("*");
+  if (streamsError || !streams) {
+    console.error("Error fetching streams:", streamsError);
+    return fail(500, { error: "Failed to fetch streams" });
+  }
+
   return {
     artists,
     releasesRaw,
     releasesHydrated: sortReleasesByDate(releasesHydrated),
     songs,
+    streams,
   };
 };

--- a/dashboard/src/routes/+layout.server.ts
+++ b/dashboard/src/routes/+layout.server.ts
@@ -9,6 +9,7 @@ import type {
 } from "../../../shared/types";
 import { sortReleasesByDate } from "../../../shared/utils";
 import type { LayoutServerLoad } from "./$types";
+import { POWER_USER_ID } from "$lib/config";
 
 export const load: LayoutServerLoad = async ({
   locals: { safeGetSession },
@@ -16,13 +17,49 @@ export const load: LayoutServerLoad = async ({
 }) => {
   const { session, user } = await safeGetSession();
 
+  if (!session || !user) {
+    return fail(401, { error: "Unauthorized" });
+  }
+
   const {
-    data: artists,
+    data: userData,
+    error: userError,
+  }: {
+    data: { artist_id: string }[] | null;
+    error: Error | null;
+  } = await supabase
+    .from("artist_members")
+    .select("artist_id")
+    .eq("user_id", session.user.id);
+
+  if (userError || !userData) {
+    console.error("Error fetching user data:", userError);
+    return fail(500, { error: "Failed to fetch user data" });
+  }
+
+  // Get all artist IDs for the user, unless they are a power user
+  // in which case fetch all artists
+  const {
+    data: connectedArtists,
     error: artistsError,
   }: {
     data: ArtistRaw[] | null;
     error: Error | null;
-  } = await supabase.from("artists").select("*");
+  } =
+    session.user.id === POWER_USER_ID
+      ? await supabase.from("artists").select("*")
+      : await supabase
+          .from("artists")
+          .select("*")
+          .in(
+            "id",
+            userData.map((u) => u.artist_id)
+          );
+
+  if (artistsError || !connectedArtists) {
+    console.error("Error fetching artists:", artistsError);
+    return fail(500, { error: "Failed to fetch artists" });
+  }
 
   const {
     data: songs,
@@ -52,7 +89,7 @@ export const load: LayoutServerLoad = async ({
     error: Error | null;
   } = await supabase.from("hydrated_releases").select("*");
 
-  if (artistsError || !artists) {
+  if (artistsError || !connectedArtists) {
     console.error("Error fetching artists:", artistsError);
     return fail(500, { error: "Failed to fetch artists" });
   }
@@ -77,7 +114,7 @@ export const load: LayoutServerLoad = async ({
     return 0;
   });
 
-  artists.sort((a, b) => {
+  connectedArtists.sort((a, b) => {
     if (a.name < b.name) return -1;
     if (a.name > b.name) return 1;
     return 0;
@@ -100,7 +137,7 @@ export const load: LayoutServerLoad = async ({
     session,
     user,
     cookies: cookies.getAll(),
-    artists,
+    artists: connectedArtists,
     releasesRaw,
     releasesHydrated: sortReleasesByDate(releasesHydrated),
     songs,

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -2,10 +2,22 @@
   import "../../../shared/styles/reset.css";
   import "../../../shared/styles/global.css";
   import { dashboardState, type DashboardSectionId } from "$lib/state.svelte";
+  import { invalidate } from "$app/navigation";
+  import { onMount } from "svelte";
 
   let { children, data } = $props();
 
+  let { supabase, session } = $state(data);
   const artists = $derived(data.artists);
+
+  onMount(() => {
+    const { data } = supabase.auth.onAuthStateChange((event, newSession) => {
+      if (newSession?.expires_at !== session?.expires_at) {
+        invalidate("supabase:auth");
+      }
+    });
+    return () => data.subscription.unsubscribe();
+  });
 
   const dashboardSections: { id: DashboardSectionId; name: string }[] = [
     { id: "profile", name: "Profile" },

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
   import { dashboardState, type DashboardSectionId } from "$lib/state.svelte";
   import { invalidate } from "$app/navigation";
   import { onMount } from "svelte";
+  import { redirect } from "@sveltejs/kit";
 
   let { children, data } = $props();
 
@@ -77,6 +78,15 @@
         </div>
       {/each}
     {/if}
+    <hr />
+    <button
+      onclick={async () => {
+        await supabase.auth.signOut();
+        redirect(303, "/login");
+      }}
+    >
+      Log out
+    </button>
   </div>
 
   <main>

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -4,13 +4,23 @@
   import { dashboardState, type DashboardSectionId } from "$lib/state.svelte";
   import { invalidate } from "$app/navigation";
   import { onMount } from "svelte";
-  import { redirect } from "@sveltejs/kit";
+  import { type SubmitFunction } from "@sveltejs/kit";
   import { dev } from "$app/environment";
+  import { enhance } from "$app/forms";
 
   let { children, data } = $props();
 
   let { supabase, session } = $state(data);
+  let loading = $state(false);
   const artists = $derived(data.artists);
+
+  const handleSignOut: SubmitFunction = () => {
+    loading = true;
+    return async ({ update }) => {
+      loading = false;
+      update();
+    };
+  };
 
   onMount(() => {
     const { data } = supabase.auth.onAuthStateChange((event, newSession) => {
@@ -82,14 +92,11 @@
         {/each}
       {/if}
       <hr />
-      <button
-        onclick={async () => {
-          await supabase.auth.signOut();
-          redirect(303, "/login");
-        }}
-      >
-        Log out
-      </button>
+      <form method="post" action="?/signout" use:enhance={handleSignOut}>
+        <div>
+          <button class="button block" disabled={loading}>Sign Out</button>
+        </div>
+      </form>
     </div>
   {/if}
 

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -11,7 +11,7 @@
     { id: "profile", name: "Profile" },
     { id: "music", name: "Music" },
     { id: "stats", name: "Stats" },
-    { id: "payouts", name: "Payouts" },
+    // { id: "payouts", name: "Payouts" },
   ];
 </script>
 

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -34,6 +34,7 @@
     <div class="side-panel">
       <h1>Soli • Dashboard</h1>
       <hr />
+      <div>User: {session?.user?.email}</div>
       {#if artists}
         <h3>Your linked artists</h3>
         <select

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -1,11 +1,18 @@
-<script>
+<script lang="ts">
   import "../../../shared/styles/reset.css";
   import "../../../shared/styles/global.css";
-  import { dashboardState } from "$lib/state.svelte";
+  import { dashboardState, type DashboardSectionId } from "$lib/state.svelte";
 
   let { children, data } = $props();
 
   const artists = $derived(data.artists);
+
+  const dashboardSections: { id: DashboardSectionId; name: string }[] = [
+    { id: "profile", name: "Profile" },
+    { id: "music", name: "Music" },
+    // { id: "stats", name: "Stats" },
+    // { id: "payouts", name: "Payouts" },
+  ];
 </script>
 
 <div class="dashboard-container">
@@ -14,28 +21,52 @@
     <hr />
     {#if artists}
       <h3>Artists</h3>
-      {#each artists as artist}
-        <div
-          class="artist-selector"
-          onclick={() => {
-            if (dashboardState.activeArtist?.id !== artist.id) {
-              dashboardState.activeArtist = artist;
-            } else {
-              dashboardState.activeArtist = null;
-            }
-          }}
-          onkeydown={() => (dashboardState.activeArtist = artist)}
-          tabindex="0"
-          role="button"
-          class:active={dashboardState.activeArtist?.id === artist.id}
-        >
-          {artist.name}
-        </div>
-      {/each}
+      <select
+        class="artist-selector"
+        onchange={(e) => {
+          const selectedId = (e.target as HTMLSelectElement).value;
+          dashboardState.activeArtist =
+            artists.find((a) => a.id === selectedId) || null;
+          dashboardState.activeSection = "profile";
+        }}
+      >
+        <option value="" disabled selected>Select an artist</option>
+        {#each artists as artist}
+          <option
+            value={artist.id}
+            class:active={dashboardState.activeArtist?.id === artist.id}
+          >
+            {artist.name}
+          </option>
+        {/each}
+      </select>
     {:else}
       <li>No artists found.</li>
     {/if}
+    {#if dashboardState.activeArtist}
+      <hr />
+      {#each dashboardSections as section}
+        <div
+          class="section-selector"
+          class:active={dashboardState.activeSection === section.id}
+          role="button"
+          onclick={() => {
+            dashboardState.activeSection = section.id;
+          }}
+          onkeydown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              dashboardState.activeSection = section.id;
+            }
+          }}
+          aria-label={`${section.name} Section`}
+          tabindex="0"
+        >
+          {section.name}
+        </div>
+      {/each}
+    {/if}
   </div>
+
   <main>
     {@render children()}
   </main>
@@ -54,12 +85,18 @@
     font-weight: 600;
     margin-bottom: 1rem;
   }
-  .artist-selector {
+  h3 {
+    margin: 0.5rem 0;
+  }
+  .section-selector {
     padding: 0.5rem;
     line-height: 1.1;
     cursor: pointer;
     border-radius: 4px;
     transition: background-color 0.2s ease;
+  }
+  select {
+    padding: 0.5rem;
   }
   .side-panel {
     width: 350px;

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -29,65 +29,67 @@
 </script>
 
 <div class="dashboard-container">
-  <div class="side-panel">
-    <h1>Soli • Dashboard</h1>
-    <hr />
-    {#if artists}
-      <h3>Your linked artists</h3>
-      <select
-        class="artist-selector"
-        onchange={(e) => {
-          const selectedId = (e.target as HTMLSelectElement).value;
-          dashboardState.activeArtist =
-            artists.find((a) => a.id === selectedId) || null;
-          dashboardState.activeSection = "profile";
+  {#if data.session}
+    <div class="side-panel">
+      <h1>Soli • Dashboard</h1>
+      <hr />
+      {#if artists}
+        <h3>Your linked artists</h3>
+        <select
+          class="artist-selector"
+          onchange={(e) => {
+            const selectedId = (e.target as HTMLSelectElement).value;
+            dashboardState.activeArtist =
+              artists.find((a) => a.id === selectedId) || null;
+            dashboardState.activeSection = "profile";
+          }}
+        >
+          <option value="" disabled selected>Select an artist</option>
+          {#each artists as artist}
+            <option
+              value={artist.id}
+              class:active={dashboardState.activeArtist?.id === artist.id}
+            >
+              {artist.name}
+            </option>
+          {/each}
+        </select>
+      {:else}
+        <li>No artists found.</li>
+      {/if}
+      {#if dashboardState.activeArtist}
+        <hr />
+        {#each dashboardSections as section}
+          <div
+            class="section-selector"
+            class:active={dashboardState.activeSection === section.id}
+            role="button"
+            onclick={() => {
+              dashboardState.activeSection = section.id;
+            }}
+            onkeydown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                dashboardState.activeSection = section.id;
+              }
+            }}
+            aria-label={`${section.name} Section`}
+            tabindex="0"
+          >
+            {section.name}
+          </div>
+        {/each}
+      {/if}
+      <hr />
+      <button
+        onclick={async () => {
+          await supabase.auth.signOut();
+          redirect(303, "/login");
         }}
       >
-        <option value="" disabled selected>Select an artist</option>
-        {#each artists as artist}
-          <option
-            value={artist.id}
-            class:active={dashboardState.activeArtist?.id === artist.id}
-          >
-            {artist.name}
-          </option>
-        {/each}
-      </select>
-    {:else}
-      <li>No artists found.</li>
-    {/if}
-    {#if dashboardState.activeArtist}
-      <hr />
-      {#each dashboardSections as section}
-        <div
-          class="section-selector"
-          class:active={dashboardState.activeSection === section.id}
-          role="button"
-          onclick={() => {
-            dashboardState.activeSection = section.id;
-          }}
-          onkeydown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              dashboardState.activeSection = section.id;
-            }
-          }}
-          aria-label={`${section.name} Section`}
-          tabindex="0"
-        >
-          {section.name}
-        </div>
-      {/each}
-    {/if}
-    <hr />
-    <button
-      onclick={async () => {
-        await supabase.auth.signOut();
-        redirect(303, "/login");
-      }}
-    >
-      Log out
-    </button>
-  </div>
+        Log out
+      </button>
+    </div>
+  {/if}
 
   <main>
     {@render children()}

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -5,6 +5,7 @@
   import { invalidate } from "$app/navigation";
   import { onMount } from "svelte";
   import { redirect } from "@sveltejs/kit";
+  import { dev } from "$app/environment";
 
   let { children, data } = $props();
 
@@ -29,7 +30,7 @@
 </script>
 
 <div class="dashboard-container">
-  {#if data.session}
+  {#if data.session || dev}
     <div class="side-panel">
       <h1>Soli • Dashboard</h1>
       <hr />

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -10,8 +10,8 @@
   const dashboardSections: { id: DashboardSectionId; name: string }[] = [
     { id: "profile", name: "Profile" },
     { id: "music", name: "Music" },
-    // { id: "stats", name: "Stats" },
-    // { id: "payouts", name: "Payouts" },
+    { id: "stats", name: "Stats" },
+    { id: "payouts", name: "Payouts" },
   ];
 </script>
 
@@ -97,6 +97,7 @@
   }
   select {
     padding: 0.5rem;
+    border-radius: 4px;
   }
   .side-panel {
     width: 350px;

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -32,7 +32,7 @@
     <h1>Soli • Dashboard</h1>
     <hr />
     {#if artists}
-      <h3>Artists</h3>
+      <h3>Your linked artists</h3>
       <select
         class="artist-selector"
         onchange={(e) => {

--- a/dashboard/src/routes/+layout.ts
+++ b/dashboard/src/routes/+layout.ts
@@ -21,23 +21,15 @@ export const load: LayoutLoad = async ({ fetch, data, depends }) => {
         },
         cookies: {
           getAll() {
-            return data.cookies;
+            return data.cookies ?? null;
           },
         },
       });
 
-  /**
-   * It's fine to use `getSession` here, because on the client, `getSession` is
-   * safe, and on the server, it reads `session` from the `LayoutData`, which
-   * safely checked the session using `safeGetSession`.
-   */
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-
   return {
     supabase,
-    session,
+    session: data.session ?? null,
+    user: data.user,
     artists: data.artists,
     releasesRaw: data.releasesRaw,
     releasesHydrated: data.releasesHydrated,

--- a/dashboard/src/routes/+layout.ts
+++ b/dashboard/src/routes/+layout.ts
@@ -5,6 +5,7 @@ import {
 } from "@supabase/ssr";
 import type { LayoutLoad } from "./$types";
 import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL } from "$lib/config";
+import { cookieOptions } from "../../../shared/utils/cookies";
 
 export const load: LayoutLoad = async ({ fetch, data, depends }) => {
   depends("supabase:auth");
@@ -14,6 +15,7 @@ export const load: LayoutLoad = async ({ fetch, data, depends }) => {
         global: {
           fetch,
         },
+        cookieOptions,
       })
     : createServerClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
         global: {
@@ -24,6 +26,7 @@ export const load: LayoutLoad = async ({ fetch, data, depends }) => {
             return data.cookies ?? null;
           },
         },
+        cookieOptions,
       });
 
   return {

--- a/dashboard/src/routes/+layout.ts
+++ b/dashboard/src/routes/+layout.ts
@@ -1,0 +1,47 @@
+import {
+  createBrowserClient,
+  createServerClient,
+  isBrowser,
+} from "@supabase/ssr";
+import type { LayoutLoad } from "./$types";
+import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL } from "$lib/config";
+
+export const load: LayoutLoad = async ({ fetch, data, depends }) => {
+  depends("supabase:auth");
+
+  const supabase = isBrowser()
+    ? createBrowserClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
+        global: {
+          fetch,
+        },
+      })
+    : createServerClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
+        global: {
+          fetch,
+        },
+        cookies: {
+          getAll() {
+            return data.cookies;
+          },
+        },
+      });
+
+  /**
+   * It's fine to use `getSession` here, because on the client, `getSession` is
+   * safe, and on the server, it reads `session` from the `LayoutData`, which
+   * safely checked the session using `safeGetSession`.
+   */
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  return {
+    supabase,
+    session,
+    artists: data.artists,
+    releasesRaw: data.releasesRaw,
+    releasesHydrated: data.releasesHydrated,
+    songs: data.songs,
+    streams: data.streams,
+  };
+};

--- a/dashboard/src/routes/+page.server.ts
+++ b/dashboard/src/routes/+page.server.ts
@@ -184,10 +184,13 @@ export const actions: Actions = {
     try {
       const formData = await request.formData();
       const artistId = formData.get("artistID") as string;
-      const artistImage = formData.get("artistImage") as File | null;
+      const artistExistingImageCID = formData.get("existingImageCID") as
+        | string
+        | undefined;
+      const artistImage = formData.get("artistImageNew") as File | null;
       const artistName = formData.get("artistName") as string;
-      const artistBio = formData.get("artistBio") as string;
-      const artistWebsite = formData.get("artistWebsite") as string;
+      const artistBio = formData.get("artistBio") as string | undefined;
+      const artistWebsite = formData.get("artistWebsite") as string | undefined;
 
       if (!artistId) {
         return fail(400, {
@@ -196,8 +199,8 @@ export const actions: Actions = {
         });
       }
 
-      let imageCid: string | null = null;
-      if (artistImage) {
+      let imageCid: string | undefined = artistExistingImageCID;
+      if (artistImage && artistImage.size > 0) {
         const pinataFileName = `${artistName} profile image`;
         const upload = await pinata.upload.public
           .file(artistImage)
@@ -211,6 +214,7 @@ export const actions: Actions = {
             message: "Failed to upload artist image to Pinata",
           });
         }
+        // TODO: Delete old artist image if it exists
         imageCid = upload.cid;
       }
 

--- a/dashboard/src/routes/+page.server.ts
+++ b/dashboard/src/routes/+page.server.ts
@@ -180,4 +180,61 @@ export const actions: Actions = {
       return json({ error: "Internal Server Error" }, { status: 500 });
     }
   },
+  updateArtistDetails: async ({ request }) => {
+    try {
+      const formData = await request.formData();
+      const artistId = formData.get("artistID") as string;
+      const artistImage = formData.get("artistImage") as File | null;
+      const artistName = formData.get("artistName") as string;
+      const artistBio = formData.get("artistBio") as string;
+      const artistWebsite = formData.get("artistWebsite") as string;
+
+      if (!artistId) {
+        return fail(400, {
+          error: true,
+          message: "Artist ID required",
+        });
+      }
+
+      let imageCid: string | null = null;
+      if (artistImage) {
+        const pinataFileName = `${artistName} profile image`;
+        const upload = await pinata.upload.public
+          .file(artistImage)
+          .name(pinataFileName)
+          .group("49d68c8c-764d-467d-b74c-9f64e8bc9647");
+
+        if (!upload || !upload.cid) {
+          console.error("Error uploading artist image to Pinata:", upload);
+          return fail(500, {
+            error: true,
+            message: "Failed to upload artist image to Pinata",
+          });
+        }
+        imageCid = upload.cid;
+      }
+
+      const { error } = await supabase
+        .from("artists")
+        .update({
+          bio: artistBio,
+          website_url: artistWebsite,
+          image_ipfs_cid: imageCid,
+        })
+        .eq("id", artistId);
+
+      if (error) {
+        console.error("Error updating artist details:", error);
+        return fail(500, {
+          error: true,
+          message: "Failed to update artist details",
+        });
+      }
+
+      return { status: 200, message: "Artist details updated successfully" };
+    } catch (error) {
+      console.log(error);
+      return json({ error: "Internal Server Error" }, { status: 500 });
+    }
+  },
 };

--- a/dashboard/src/routes/+page.server.ts
+++ b/dashboard/src/routes/+page.server.ts
@@ -1,4 +1,4 @@
-import { fail, json, type Actions } from "@sveltejs/kit";
+import { fail, json, redirect, type Actions } from "@sveltejs/kit";
 import { pinata } from "$lib/server/pinata";
 import { supabase } from "$lib/server/stripe";
 import { parseFile } from "music-metadata";
@@ -239,6 +239,13 @@ export const actions: Actions = {
     } catch (error) {
       console.log(error);
       return json({ error: "Internal Server Error" }, { status: 500 });
+    }
+  },
+  signout: async ({ locals: { supabase, safeGetSession } }) => {
+    const { session } = await safeGetSession();
+    if (session) {
+      await supabase.auth.signOut();
+      redirect(303, "/");
     }
   },
 };

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -10,6 +10,8 @@
   import { dashboardState } from "$lib/state.svelte";
   import Card from "$lib/components/Card.svelte";
   import ReleaseInfo from "$lib/components/ReleaseInfo.svelte";
+  import { PUBLIC_GATEWAY_URL } from "$env/static/public";
+  import ProfileSummary from "$lib/components/ProfileSummary.svelte";
 
   let {
     form,
@@ -46,6 +48,10 @@
       uploading = false;
     };
   }
+
+  export const makeImageLink = (cid: string, width: number) => {
+    return `https://${PUBLIC_GATEWAY_URL}/ipfs/${cid}?img-width=${width}`;
+  };
 </script>
 
 <svelte:head>
@@ -55,156 +61,170 @@
 
 <div class="dashboard">
   {#if activeArtist}
-    <div class="releases-list">
-      <h2>
-        Releases ({activeArtistReleasesHydrated.length})
-      </h2>
-      {#each activeArtistReleasesHydrated as release}
-        <Card>
-          <ReleaseInfo {release} />
-        </Card>
-      {/each}
-    </div>
-    <div class="songs-list">
-      <h2>
-        Songs ({activeArtistSongs.length})
-      </h2>
-      {#each activeArtistSongs as song}
-        <Card>
-          <div>{song.title}</div>
-        </Card>
-      {/each}
-    </div>
-    <div class="forms">
-      <div class="upload-form">
-        <h2>Upload a song</h2>
-        <form
-          method="POST"
-          enctype="multipart/form-data"
-          action="?/uploadTrack"
-          use:enhance={handleUpload}
-        >
-          <input type="file" id="file" name="fileToUpload" accept=".mp3" />
-          <label for="file">Choose an MP3 file</label>
-          <input type="text" name="title" placeholder="Title" required />
-          <input
-            type="text"
-            name="artistName"
-            value={activeArtist.name}
-            class="hidden"
-            required
-          />
-          <input
-            type="text"
-            name="artistID"
-            value={activeArtist.id}
-            class="hidden"
-            required
-          />
-          <input
-            type="text"
-            name="artistGroup"
-            value={activeArtist.pinata_group_id}
-            class="hidden"
-            required
-          />
-          <button disabled={uploading} type="submit">
-            {uploading ? "Uploading..." : "Upload"}
-          </button>
-        </form>
-        {#if form && form.status === 200}
-          <div>File uploaded successfully!</div>
-        {/if}
+    {#if dashboardState.activeSection === "music"}
+      <div class="releases-list">
+        <h2>
+          Releases ({activeArtistReleasesHydrated.length})
+        </h2>
+        {#each activeArtistReleasesHydrated as release}
+          <Card>
+            <ReleaseInfo {release} />
+          </Card>
+        {/each}
       </div>
-      <div class="add-release-form">
-        <h2>Add a release</h2>
-        <form
-          method="POST"
-          action="?/addRelease"
-          enctype="multipart/form-data"
-          use:enhance={handleUpload}
-        >
-          <input
-            type="file"
-            id="releaseArtwork"
-            name="releaseArtwork"
-            accept=".jpg,.jpeg,.png"
-          />
-          <label for="releaseArtwork">Choose release artwork</label>
-          <input
-            type="text"
-            name="releaseTitle"
-            placeholder="Release Title"
-            required
-          />
-          <select name="releaseType" required>
-            <option value="" disabled selected>Select release type</option>
-            <option value="album">album</option>
-            <option value="single">single</option>
-            <option value="ep">ep</option>
-          </select>
-          <input
-            type="text"
-            name="artistID"
-            value={activeArtist.id}
-            class="hidden"
-            required
-          />
-          <input
-            type="date"
-            name="releaseDate"
-            placeholder="Release Date"
-            required
-          />
-          <input
-            type="text"
-            name="releaseTags"
-            placeholder="Tags (comma-separated)"
-            required
-          />
-          <button disabled={uploading} type="submit">
-            {uploading ? "Adding..." : "Add Release"}
-          </button>
-        </form>
-        {#if form && form.status === 200}
-          <p>Release added successfully!</p>
-        {/if}
+      <div class="songs-list">
+        <h2>
+          Songs ({activeArtistSongs.length})
+        </h2>
+        {#each activeArtistSongs as song}
+          <Card>
+            <div>{song.title}</div>
+          </Card>
+        {/each}
       </div>
-      <div class="add-track-to-release-form">
-        <h2>Add a track to release</h2>
-        <form
-          method="POST"
-          action="?/addTrackToRelease"
-          use:enhance={handleUpload}
-        >
-          <select name="releaseID" required>
-            <option value="" disabled selected>Select a release</option>
-            {#each activeArtistReleasesRaw as release}
-              <option value={release.id}>{release.title}</option>
-            {/each}
-          </select>
-          <select name="trackID" required>
-            <option value="" disabled selected>Select a track</option>
-            {#each activeArtistSongs as song}
-              <option value={song.id}>{song.title}</option>
-            {/each}
-          </select>
-          <input
-            type="number"
-            name="trackNumber"
-            placeholder="Track Number"
-            min="1"
-            required
-          />
-          <button disabled={uploading} type="submit">
-            {uploading ? "Adding..." : "Add Track"}
-          </button>
-        </form>
-        {#if form && form.status === 200}
-          <p>Track added to release successfully!</p>
-        {/if}
+      <div class="forms">
+        <div class="upload-form">
+          <h2>Upload a song</h2>
+          <form
+            method="POST"
+            enctype="multipart/form-data"
+            action="?/uploadTrack"
+            use:enhance={handleUpload}
+          >
+            <input type="file" id="file" name="fileToUpload" accept=".mp3" />
+            <label for="file">Choose an MP3 file</label>
+            <input type="text" name="title" placeholder="Title" required />
+            <input
+              type="text"
+              name="artistName"
+              value={activeArtist.name}
+              class="hidden"
+              required
+            />
+            <input
+              type="text"
+              name="artistID"
+              value={activeArtist.id}
+              class="hidden"
+              required
+            />
+            <input
+              type="text"
+              name="artistGroup"
+              value={activeArtist.pinata_group_id}
+              class="hidden"
+              required
+            />
+            <button disabled={uploading} type="submit">
+              {uploading ? "Uploading..." : "Upload"}
+            </button>
+          </form>
+          {#if form && form.status === 200}
+            <div>File uploaded successfully!</div>
+          {/if}
+        </div>
+        <div class="add-release-form">
+          <h2>Add a release</h2>
+          <form
+            method="POST"
+            action="?/addRelease"
+            enctype="multipart/form-data"
+            use:enhance={handleUpload}
+          >
+            <input
+              type="file"
+              id="releaseArtwork"
+              name="releaseArtwork"
+              accept=".jpg,.jpeg,.png"
+            />
+            <label for="releaseArtwork">Choose release artwork</label>
+            <input
+              type="text"
+              name="releaseTitle"
+              placeholder="Release Title"
+              required
+            />
+            <select name="releaseType" required>
+              <option value="" disabled selected>Select release type</option>
+              <option value="album">album</option>
+              <option value="single">single</option>
+              <option value="ep">ep</option>
+            </select>
+            <input
+              type="text"
+              name="artistID"
+              value={activeArtist.id}
+              class="hidden"
+              required
+            />
+            <input
+              type="date"
+              name="releaseDate"
+              placeholder="Release Date"
+              required
+            />
+            <input
+              type="text"
+              name="releaseTags"
+              placeholder="Tags (comma-separated)"
+              required
+            />
+            <button disabled={uploading} type="submit">
+              {uploading ? "Adding..." : "Add Release"}
+            </button>
+          </form>
+          {#if form && form.status === 200}
+            <p>Release added successfully!</p>
+          {/if}
+        </div>
+        <div class="add-track-to-release-form">
+          <h2>Add a track to release</h2>
+          <form
+            method="POST"
+            action="?/addTrackToRelease"
+            use:enhance={handleUpload}
+          >
+            <select name="releaseID" required>
+              <option value="" disabled selected>Select a release</option>
+              {#each activeArtistReleasesRaw as release}
+                <option value={release.id}>{release.title}</option>
+              {/each}
+            </select>
+            <select name="trackID" required>
+              <option value="" disabled selected>Select a track</option>
+              {#each activeArtistSongs as song}
+                <option value={song.id}>{song.title}</option>
+              {/each}
+            </select>
+            <input
+              type="number"
+              name="trackNumber"
+              placeholder="Track Number"
+              min="1"
+              required
+            />
+            <button disabled={uploading} type="submit">
+              {uploading ? "Adding..." : "Add Track"}
+            </button>
+          </form>
+          {#if form && form.status === 200}
+            <p>Track added to release successfully!</p>
+          {/if}
+        </div>
       </div>
-    </div>
+    {:else if dashboardState.activeSection === "profile"}
+      <ProfileSummary {activeArtist} />
+      <!-- {:else if dashboardState.activeSection === "stats"}
+      <div class="artist-stats">
+        <h2>Stats</h2>
+        <p>Coming soon...</p>
+      </div>
+    {:else if dashboardState.activeSection === "payouts"}
+      <div class="artist-payouts">
+        <h2>Payouts</h2>
+        <p>Coming soon...</p>
+      </div> -->
+    {/if}
   {:else}
     <div>Select an artist to manage their releases and songs.</div>
   {/if}

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -12,6 +12,7 @@
   import ReleaseInfo from "$lib/components/ReleaseInfo.svelte";
   import { PUBLIC_GATEWAY_URL } from "$env/static/public";
   import ProfileSummary from "$lib/components/ProfileSummary.svelte";
+  import { prettifyDuration } from "../../../shared/utils";
 
   let {
     form,
@@ -78,7 +79,12 @@
         </h2>
         {#each activeArtistSongs as song}
           <Card>
-            <div>{song.title}</div>
+            <div class="song-wrapper">
+              <div>{song.title}</div>
+              <div>
+                <small>{prettifyDuration(song.duration_seconds)}</small>
+              </div>
+            </div>
           </Card>
         {/each}
       </div>
@@ -268,5 +274,14 @@
     flex-direction: column;
     gap: 2rem;
     flex: 1;
+  }
+  .song-wrapper {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  small {
+    font-weight: 500;
+    font-size: 70%;
   }
 </style>

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -5,6 +5,7 @@
     ArtistRaw,
     ReleaseHydrated,
     ReleaseRaw,
+    StreamLog,
     TrackRaw,
   } from "../../../shared/types";
   import { dashboardState } from "$lib/state.svelte";
@@ -25,6 +26,7 @@
       songs: TrackRaw[];
       releasesRaw: ReleaseRaw[];
       releasesHydrated: ReleaseHydrated[];
+      streams: StreamLog[];
     };
   } = $props();
 
@@ -41,6 +43,24 @@
       (release) => release.artist_id === activeArtist?.id
     )
   );
+  let activeArtistStreams = $derived(
+    data.streams.filter((stream) => stream.artist_id === activeArtist?.id)
+  );
+
+  const calculateAveragePayout = (streams: StreamLog[]) => {
+    const total = streams.reduce((acc, stream) => acc + stream.tokens_used, 0);
+    return total / streams.length || 0;
+  };
+
+  const calculateTotalEarnings = (
+    streams: StreamLog[],
+    outputFormat: "readable-string" | "raw"
+  ) => {
+    const total = streams.reduce((acc, stream) => acc + stream.tokens_used, 0);
+    return outputFormat === "readable-string"
+      ? `£${(total / 100).toFixed(2)}`
+      : total / 100;
+  };
 
   function handleUpload() {
     uploading = true;
@@ -60,175 +80,190 @@
   <meta name="description" content="Upload and manage your music." />
 </svelte:head>
 
-<div class="dashboard">
+<div>
   {#if activeArtist}
     {#if dashboardState.activeSection === "music"}
-      <div class="releases-list">
-        <h2>
-          Releases ({activeArtistReleasesHydrated.length})
-        </h2>
-        {#each activeArtistReleasesHydrated as release}
-          <Card>
-            <ReleaseInfo {release} />
-          </Card>
-        {/each}
-      </div>
-      <div class="songs-list">
-        <h2>
-          Songs ({activeArtistSongs.length})
-        </h2>
-        {#each activeArtistSongs as song}
-          <Card>
-            <div class="song-wrapper">
-              <div>{song.title}</div>
-              <div>
-                <small>{prettifyDuration(song.duration_seconds)}</small>
+      <div class="dashboard">
+        <div class="releases-list">
+          <h2>
+            Releases ({activeArtistReleasesHydrated.length})
+          </h2>
+          {#each activeArtistReleasesHydrated as release}
+            <Card>
+              <ReleaseInfo {release} />
+            </Card>
+          {/each}
+        </div>
+        <div class="songs-list">
+          <h2>
+            Songs ({activeArtistSongs.length})
+          </h2>
+          {#each activeArtistSongs as song}
+            <Card>
+              <div class="song-wrapper">
+                <div>{song.title}</div>
+                <div>
+                  <small>{prettifyDuration(song.duration_seconds)}</small>
+                </div>
               </div>
-            </div>
-          </Card>
-        {/each}
-      </div>
-      <div class="forms">
-        <div class="upload-form">
-          <h2>Upload a song</h2>
-          <form
-            method="POST"
-            enctype="multipart/form-data"
-            action="?/uploadTrack"
-            use:enhance={handleUpload}
-          >
-            <input type="file" id="file" name="fileToUpload" accept=".mp3" />
-            <label for="file">Choose an MP3 file</label>
-            <input type="text" name="title" placeholder="Title" required />
-            <input
-              type="text"
-              name="artistName"
-              value={activeArtist.name}
-              class="hidden"
-              required
-            />
-            <input
-              type="text"
-              name="artistID"
-              value={activeArtist.id}
-              class="hidden"
-              required
-            />
-            <input
-              type="text"
-              name="artistGroup"
-              value={activeArtist.pinata_group_id}
-              class="hidden"
-              required
-            />
-            <button disabled={uploading} type="submit">
-              {uploading ? "Uploading..." : "Upload"}
-            </button>
-          </form>
-          {#if form && form.status === 200}
-            <div>File uploaded successfully!</div>
-          {/if}
+            </Card>
+          {/each}
         </div>
-        <div class="add-release-form">
-          <h2>Add a release</h2>
-          <form
-            method="POST"
-            action="?/addRelease"
-            enctype="multipart/form-data"
-            use:enhance={handleUpload}
-          >
-            <input
-              type="file"
-              id="releaseArtwork"
-              name="releaseArtwork"
-              accept=".jpg,.jpeg,.png"
-            />
-            <label for="releaseArtwork">Choose release artwork</label>
-            <input
-              type="text"
-              name="releaseTitle"
-              placeholder="Release Title"
-              required
-            />
-            <select name="releaseType" required>
-              <option value="" disabled selected>Select release type</option>
-              <option value="album">album</option>
-              <option value="single">single</option>
-              <option value="ep">ep</option>
-            </select>
-            <input
-              type="text"
-              name="artistID"
-              value={activeArtist.id}
-              class="hidden"
-              required
-            />
-            <input
-              type="date"
-              name="releaseDate"
-              placeholder="Release Date"
-              required
-            />
-            <input
-              type="text"
-              name="releaseTags"
-              placeholder="Tags (comma-separated)"
-              required
-            />
-            <button disabled={uploading} type="submit">
-              {uploading ? "Adding..." : "Add Release"}
-            </button>
-          </form>
-          {#if form && form.status === 200}
-            <p>Release added successfully!</p>
-          {/if}
-        </div>
-        <div class="add-track-to-release-form">
-          <h2>Add a track to release</h2>
-          <form
-            method="POST"
-            action="?/addTrackToRelease"
-            use:enhance={handleUpload}
-          >
-            <select name="releaseID" required>
-              <option value="" disabled selected>Select a release</option>
-              {#each activeArtistReleasesRaw as release}
-                <option value={release.id}>{release.title}</option>
-              {/each}
-            </select>
-            <select name="trackID" required>
-              <option value="" disabled selected>Select a track</option>
-              {#each activeArtistSongs as song}
-                <option value={song.id}>{song.title}</option>
-              {/each}
-            </select>
-            <input
-              type="number"
-              name="trackNumber"
-              placeholder="Track Number"
-              min="1"
-              required
-            />
-            <button disabled={uploading} type="submit">
-              {uploading ? "Adding..." : "Add Track"}
-            </button>
-          </form>
-          {#if form && form.status === 200}
-            <p>Track added to release successfully!</p>
-          {/if}
+        <div class="forms">
+          <div class="upload-form">
+            <h2>Upload a song</h2>
+            <form
+              method="POST"
+              enctype="multipart/form-data"
+              action="?/uploadTrack"
+              use:enhance={handleUpload}
+            >
+              <input type="file" id="file" name="fileToUpload" accept=".mp3" />
+              <label for="file">Choose an MP3 file</label>
+              <input type="text" name="title" placeholder="Title" required />
+              <input
+                type="text"
+                name="artistName"
+                value={activeArtist.name}
+                class="hidden"
+                required
+              />
+              <input
+                type="text"
+                name="artistID"
+                value={activeArtist.id}
+                class="hidden"
+                required
+              />
+              <input
+                type="text"
+                name="artistGroup"
+                value={activeArtist.pinata_group_id}
+                class="hidden"
+                required
+              />
+              <button disabled={uploading} type="submit">
+                {uploading ? "Uploading..." : "Upload"}
+              </button>
+            </form>
+            {#if form && form.status === 200}
+              <div>File uploaded successfully!</div>
+            {/if}
+          </div>
+          <div class="add-release-form">
+            <h2>Add a release</h2>
+            <form
+              method="POST"
+              action="?/addRelease"
+              enctype="multipart/form-data"
+              use:enhance={handleUpload}
+            >
+              <input
+                type="file"
+                id="releaseArtwork"
+                name="releaseArtwork"
+                accept=".jpg,.jpeg,.png"
+              />
+              <label for="releaseArtwork">Choose release artwork</label>
+              <input
+                type="text"
+                name="releaseTitle"
+                placeholder="Release Title"
+                required
+              />
+              <select name="releaseType" required>
+                <option value="" disabled selected>Select release type</option>
+                <option value="album">album</option>
+                <option value="single">single</option>
+                <option value="ep">ep</option>
+              </select>
+              <input
+                type="text"
+                name="artistID"
+                value={activeArtist.id}
+                class="hidden"
+                required
+              />
+              <input
+                type="date"
+                name="releaseDate"
+                placeholder="Release Date"
+                required
+              />
+              <input
+                type="text"
+                name="releaseTags"
+                placeholder="Tags (comma-separated)"
+                required
+              />
+              <button disabled={uploading} type="submit">
+                {uploading ? "Adding..." : "Add Release"}
+              </button>
+            </form>
+            {#if form && form.status === 200}
+              <p>Release added successfully!</p>
+            {/if}
+          </div>
+          <div class="add-track-to-release-form">
+            <h2>Add a track to release</h2>
+            <form
+              method="POST"
+              action="?/addTrackToRelease"
+              use:enhance={handleUpload}
+            >
+              <select name="releaseID" required>
+                <option value="" disabled selected>Select a release</option>
+                {#each activeArtistReleasesRaw as release}
+                  <option value={release.id}>{release.title}</option>
+                {/each}
+              </select>
+              <select name="trackID" required>
+                <option value="" disabled selected>Select a track</option>
+                {#each activeArtistSongs as song}
+                  <option value={song.id}>{song.title}</option>
+                {/each}
+              </select>
+              <input
+                type="number"
+                name="trackNumber"
+                placeholder="Track Number"
+                min="1"
+                required
+              />
+              <button disabled={uploading} type="submit">
+                {uploading ? "Adding..." : "Add Track"}
+              </button>
+            </form>
+            {#if form && form.status === 200}
+              <p>Track added to release successfully!</p>
+            {/if}
+          </div>
         </div>
       </div>
     {:else if dashboardState.activeSection === "profile"}
       <ProfileSummary {activeArtist} />
-      <!-- {:else if dashboardState.activeSection === "stats"}
+    {:else if dashboardState.activeSection === "stats"}
       <div class="artist-stats">
         <h2>Stats</h2>
-        <p>Coming soon...</p>
+        <div><strong>Total Streams:</strong> {activeArtistStreams.length}</div>
+        <div>
+          <strong>Average payout per stream:</strong>
+          {calculateAveragePayout(activeArtistStreams).toFixed(2)}p
+        </div>
+        <div>
+          <strong>Total earnings:</strong>
+          {calculateTotalEarnings(activeArtistStreams, "readable-string")}
+        </div>
       </div>
-    {:else if dashboardState.activeSection === "payouts"}
+      <!-- {:else if dashboardState.activeSection === "payouts"}
       <div class="artist-payouts">
         <h2>Payouts</h2>
-        <p>Coming soon...</p>
+        <div>
+          Total earnings: {calculateTotalEarnings(
+            activeArtistStreams,
+            "readable-string"
+          )}
+        </div>
       </div> -->
     {/if}
   {:else}

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -245,7 +245,7 @@
     {:else if dashboardState.activeSection === "stats"}
       <div class="artist-stats">
         <h2>Stats</h2>
-        <div><strong>Total Streams:</strong> {activeArtistStreams.length}</div>
+        <div><strong>Total streams:</strong> {activeArtistStreams.length}</div>
         <div>
           <strong>Average payout per stream:</strong>
           {calculateAveragePayout(activeArtistStreams).toFixed(2)}p

--- a/dashboard/src/routes/auth/confirm/+server.ts
+++ b/dashboard/src/routes/auth/confirm/+server.ts
@@ -1,0 +1,31 @@
+import type { EmailOtpType } from "@supabase/supabase-js";
+import { redirect } from "@sveltejs/kit";
+
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
+  const token_hash = url.searchParams.get("token_hash");
+  const type = url.searchParams.get("type") as EmailOtpType | null;
+  const next = url.searchParams.get("next") ?? "/";
+
+  /**
+   * Clean up the redirect URL by deleting the Auth flow parameters.
+   *
+   * `next` is preserved for now, because it's needed in the error case.
+   */
+  const redirectTo = new URL(url);
+  redirectTo.pathname = next;
+  redirectTo.searchParams.delete("token_hash");
+  redirectTo.searchParams.delete("type");
+
+  if (token_hash && type) {
+    const { error } = await supabase.auth.verifyOtp({ type, token_hash });
+    if (!error) {
+      redirectTo.searchParams.delete("next");
+      redirect(303, redirectTo);
+    }
+  }
+
+  redirectTo.pathname = "/auth/error";
+  redirect(303, redirectTo);
+};

--- a/dashboard/src/routes/auth/error/+page.svelte
+++ b/dashboard/src/routes/auth/error/+page.svelte
@@ -1,0 +1,1 @@
+<p>Login error</p>

--- a/dashboard/src/routes/login/+page.server.ts
+++ b/dashboard/src/routes/login/+page.server.ts
@@ -1,0 +1,52 @@
+// src/routes/+page.server.ts
+import { fail, redirect } from "@sveltejs/kit";
+import type { Actions, PageServerLoad } from "./$types";
+
+export const load: PageServerLoad = async ({
+  url,
+  locals: { safeGetSession },
+}) => {
+  const { session } = await safeGetSession();
+
+  if (session) {
+    redirect(303, "/");
+  }
+
+  return { url: url.origin };
+};
+
+export const actions: Actions = {
+  default: async (event) => {
+    const {
+      url,
+      request,
+      locals: { supabase },
+    } = event;
+    const formData = await request.formData();
+    const email = formData.get("email") as string;
+    const validEmail = /^[\w-\.+]+@([\w-]+\.)+[\w-]{2,8}$/.test(email);
+
+    if (!validEmail) {
+      return fail(400, {
+        errors: { email: "Please enter a valid email address" },
+        email,
+      });
+    }
+
+    const { error } = await supabase.auth.signInWithOtp({ email });
+
+    if (error) {
+      return fail(400, {
+        success: false,
+        email,
+        message: `There was an issue, Please contact support.`,
+      });
+    }
+
+    return {
+      success: true,
+      message:
+        "Please check your email for a magic link to log into the website.",
+    };
+  },
+};

--- a/dashboard/src/routes/login/+page.server.ts
+++ b/dashboard/src/routes/login/+page.server.ts
@@ -46,7 +46,12 @@ export const actions: Actions = {
       });
     }
 
-    const { error } = await supabase.auth.signInWithOtp({ email });
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        emailRedirectTo: "https://dashboard.soli.network",
+      },
+    });
 
     if (error) {
       return fail(400, {

--- a/dashboard/src/routes/login/+page.server.ts
+++ b/dashboard/src/routes/login/+page.server.ts
@@ -32,6 +32,20 @@ export const actions: Actions = {
       });
     }
 
+    const { error: betaUserError } = await supabase
+      .from("beta-users")
+      .select("email")
+      .eq("email", email)
+      .single();
+
+    if (betaUserError) {
+      return fail(400, {
+        success: false,
+        email,
+        message: "Your email is not on the beta list.",
+      });
+    }
+
     const { error } = await supabase.auth.signInWithOtp({ email });
 
     if (error) {

--- a/dashboard/src/routes/login/+page.server.ts
+++ b/dashboard/src/routes/login/+page.server.ts
@@ -1,4 +1,3 @@
-// src/routes/+page.server.ts
 import { fail, redirect } from "@sveltejs/kit";
 import type { Actions, PageServerLoad } from "./$types";
 

--- a/dashboard/src/routes/login/+page.svelte
+++ b/dashboard/src/routes/login/+page.svelte
@@ -1,4 +1,3 @@
-<!-- src/routes/+page.svelte -->
 <script lang="ts">
   import { enhance } from "$app/forms";
   import type { ActionData, SubmitFunction } from "./$types.js";
@@ -6,8 +5,8 @@
   export let form: ActionData;
 
   let loading = false;
-  import { fail, redirect } from "@sveltejs/kit";
-  import type { Actions, PageServerLoad } from "./$types";
+  import { redirect } from "@sveltejs/kit";
+  import type { PageServerLoad } from "./$types";
 
   export const load: PageServerLoad = async ({
     url,
@@ -20,42 +19,6 @@
     }
 
     return { url: url.origin };
-  };
-
-  export const actions: Actions = {
-    default: async (event) => {
-      const {
-        url,
-        request,
-        locals: { supabase },
-      } = event;
-      const formData = await request.formData();
-      const email = formData.get("email") as string;
-      const validEmail = /^[\w-\.+]+@([\w-]+\.)+[\w-]{2,8}$/.test(email);
-
-      if (!validEmail) {
-        return fail(400, {
-          errors: { email: "Please enter a valid email address" },
-          email,
-        });
-      }
-
-      const { error } = await supabase.auth.signInWithOtp({ email });
-
-      if (error) {
-        return fail(400, {
-          success: false,
-          email,
-          message: `There was an issue, Please contact support.`,
-        });
-      }
-
-      return {
-        success: true,
-        message:
-          "Please check your email for a magic link to log into the website.",
-      };
-    },
   };
   const handleSubmit: SubmitFunction = () => {
     loading = true;

--- a/dashboard/src/routes/login/+page.svelte
+++ b/dashboard/src/routes/login/+page.svelte
@@ -1,0 +1,128 @@
+<!-- src/routes/+page.svelte -->
+<script lang="ts">
+  import { enhance } from "$app/forms";
+  import type { ActionData, SubmitFunction } from "./$types.js";
+
+  export let form: ActionData;
+
+  let loading = false;
+  import { fail, redirect } from "@sveltejs/kit";
+  import type { Actions, PageServerLoad } from "./$types";
+
+  export const load: PageServerLoad = async ({
+    url,
+    locals: { safeGetSession },
+  }) => {
+    const { session } = await safeGetSession();
+
+    if (session) {
+      redirect(303, "/");
+    }
+
+    return { url: url.origin };
+  };
+
+  export const actions: Actions = {
+    default: async (event) => {
+      const {
+        url,
+        request,
+        locals: { supabase },
+      } = event;
+      const formData = await request.formData();
+      const email = formData.get("email") as string;
+      const validEmail = /^[\w-\.+]+@([\w-]+\.)+[\w-]{2,8}$/.test(email);
+
+      if (!validEmail) {
+        return fail(400, {
+          errors: { email: "Please enter a valid email address" },
+          email,
+        });
+      }
+
+      const { error } = await supabase.auth.signInWithOtp({ email });
+
+      if (error) {
+        return fail(400, {
+          success: false,
+          email,
+          message: `There was an issue, Please contact support.`,
+        });
+      }
+
+      return {
+        success: true,
+        message:
+          "Please check your email for a magic link to log into the website.",
+      };
+    },
+  };
+  const handleSubmit: SubmitFunction = () => {
+    loading = true;
+    return async ({ update }) => {
+      update();
+      loading = false;
+    };
+  };
+</script>
+
+<svelte:head>
+  <title>Login • Soli</title>
+</svelte:head>
+
+<form method="POST" use:enhance={handleSubmit}>
+  <div class="wrapper">
+    <h2>Log in</h2>
+    <div class="description">
+      If you're part of the experiment, you can sign in via magic link with your
+      email below.
+    </div>
+    {#if form?.message !== undefined}
+      <div class="success {form?.success ? '' : 'fail'}">
+        {form?.message}
+      </div>
+    {/if}
+    <div>
+      <input
+        id="email"
+        name="email"
+        type="email"
+        placeholder="Your email"
+        value={form?.email ?? ""}
+      />
+    </div>
+    {#if form?.errors?.email}
+      <span>
+        {form?.errors?.email}
+      </span>
+    {/if}
+    <div>
+      <button>
+        {loading ? "Loading" : "Send magic link"}
+      </button>
+    </div>
+  </div>
+</form>
+
+<style>
+  .wrapper {
+    max-width: 400px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  h2 {
+    margin: 0;
+    line-height: 1;
+  }
+  .description {
+    line-height: 1.3;
+    margin-bottom: 0;
+  }
+  input,
+  button {
+    border-radius: 0.5rem;
+    padding: 0 0.5rem;
+  }
+</style>

--- a/dashboard/src/routes/login/+page.svelte
+++ b/dashboard/src/routes/login/+page.svelte
@@ -67,7 +67,7 @@
 </script>
 
 <svelte:head>
-  <title>Login • Soli</title>
+  <title>Login • Soli Dashboard</title>
 </svelte:head>
 
 <form method="POST" use:enhance={handleSubmit}>

--- a/dashboard/svelte.config.js
+++ b/dashboard/svelte.config.js
@@ -1,16 +1,11 @@
-import adapter from '@sveltejs/adapter-auto';
+import adapter from '@sveltejs/adapter-netlify';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	// Consult https://svelte.dev/docs/kit/integrations
-	// for more information about preprocessors
 	preprocess: vitePreprocess(),
 
 	kit: {
-		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
-		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
-		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
 		adapter: adapter()
 	}
 };

--- a/shared/styles/global.css
+++ b/shared/styles/global.css
@@ -8,7 +8,7 @@
   --color-text-secondary: #545454;
   --color-accent: #333333;
 
-  --box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+  --box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
 @media (min-width: 800px) {

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -50,3 +50,12 @@ export interface ReleaseRaw {
   created_at: string;
   updated_at: string;
 }
+
+export interface StreamLog {
+  id: string;
+  streamed_at: string;
+  user_id: string;
+  track_id: string;
+  artist_id: string;
+  tokens_used: number;
+}

--- a/shared/utils/cookies.ts
+++ b/shared/utils/cookies.ts
@@ -1,0 +1,7 @@
+export const cookieOptions = {
+  name: `sb-soli.network-auth-token`,
+  domain: "soli.network",
+  path: "/",
+  maxAge: 60 * 60 * 24 * 365, // 1 year
+  sameSite: "lax" as const,
+};


### PR DESCRIPTION
This rejigs the `dashboard` project and adds deployment config so that Soli users with connected artist accounts can edit profile details and upload music. It is housed at https://dashboard.soli.network.

I've used [this guide](https://github.com/orgs/supabase/discussions/5742#discussioncomment-13285901) in an attempt to share auth checks and cookies across multiple Soli domains/subdomains. At present I don't see why someone who's logged in to the app can't get access to the dashboard for free and vice versa. I've also adjusted the Supabase auth check to send explicit redirect addresses so that the magic links point to the right place depending on where they've been requested (https://github.com/gonzo-engineering/soli/pull/33/commits/01a2ab143a8fd716b39c08f133c8fc97d7986995).

The first pass at this is extremely rough, but it's something. A few areas for improvements have been added to the [parent epic issue](https://github.com/gonzo-engineering/soli/issues/30).