### PR TITLE
Follow artists

### DIFF
--- a/app/src/lib/global/config.ts
+++ b/app/src/lib/global/config.ts
@@ -15,7 +15,8 @@ export const TABLES = {
 	releasesHydrated: 'hydrated_releases',
 	streams: 'streams',
 	betaUsers: 'beta-users',
-	likedTracks: 'liked_tracks'
+	likedTracks: 'liked_tracks',
+	followedArtists: 'followed_artists'
 };
 
 export const PUBLIC_PATH_ROOTS = [

--- a/app/src/lib/global/state.svelte.ts
+++ b/app/src/lib/global/state.svelte.ts
@@ -42,19 +42,26 @@ const logStream = async (userId: string, artistId: string, trackId: string, toke
 	}
 };
 
-const updateUserBalance = async (userId: string, newBalance: number) => {
-	console.log('Updating balance for user:', userId, 'New balance:', newBalance);
-	const { error } = await supabase
-		.from(TABLES.users)
-		.update({ tokens_balance: newBalance })
-		.eq('id', userId)
-		.select();
-	if (error) {
-		console.error('Error updating balance:', error);
-	} else {
-		console.log('Balance updated successfully');
-		userState.liveBalance = newBalance;
+export const updateUserTokensBalance = async (
+	userId: string,
+	tokens: number,
+	addOrSubtract: 'add' | 'subtract'
+) => {
+	const balanceChange = addOrSubtract === 'add' ? tokens : -tokens;
+	const response = await fetch(`/api/users/${userId}`, {
+		method: 'PATCH',
+		headers: {
+			'Content-Type': 'application/json'
+		},
+		body: JSON.stringify({ balanceChange })
+	});
+
+	if (!response.ok) {
+		console.error('Error updating user balance:', response.statusText);
 	}
+	const data = await response.json();
+	userState.liveBalance = data.tokens_balance;
+	return { data, error: response.ok ? null : new Error(response.statusText) };
 };
 
 export const setActiveSong = async (
@@ -77,7 +84,7 @@ export const setActiveSong = async (
 	// TODO: Improve this to use a more accurate timer
 	// Deduct the pay per stream after 30 of playtime
 	setTimeout(() => {
-		updateUserBalance(userId, userBalance - userPayPerStream);
+		updateUserTokensBalance(userId, userPayPerStream, 'subtract');
 		logStream(userId, release.artist_id, song.id, userPayPerStream);
 	}, 30000);
 };

--- a/app/src/routes/+layout.server.ts
+++ b/app/src/routes/+layout.server.ts
@@ -14,6 +14,7 @@ export const load: LayoutServerLoad = async ({
 		track: TrackRaw;
 		release: ReleaseHydrated | null;
 	}[] = [];
+	let followedIDs: string[] = [];
 
 	if (session) {
 		const {
@@ -54,6 +55,14 @@ export const load: LayoutServerLoad = async ({
 			likedTrack.release = release;
 		}
 		likedTracks = likedTracks.filter((t) => t.release);
+
+		const followedArtistIDs = await supabase
+			.from(TABLES.followedArtists)
+			.select('artist_id')
+			.eq('user_id', session.user.id);
+		if (followedArtistIDs.data) {
+			followedIDs = followedArtistIDs.data.map((a) => a.artist_id);
+		}
 	}
 
 	return {
@@ -61,6 +70,7 @@ export const load: LayoutServerLoad = async ({
 		user,
 		profileData,
 		likedTracks,
+		followedArtists: followedIDs,
 		cookies: cookies.getAll()
 	};
 };

--- a/app/src/routes/+layout.server.ts
+++ b/app/src/routes/+layout.server.ts
@@ -9,7 +9,7 @@ export const load: LayoutServerLoad = async ({
 }) => {
 	const { session, user } = await safeGetSession();
 
-	let profileData = null;
+	let profileData: UserProfile | null = null;
 	let likedTracks: {
 		track: TrackRaw;
 		release: ReleaseHydrated | null;
@@ -17,16 +17,7 @@ export const load: LayoutServerLoad = async ({
 	let followedIDs: string[] = [];
 
 	if (session) {
-		const {
-			data: profile
-		}: {
-			data: UserProfile | null;
-		} = await supabase
-			.from(TABLES.users)
-			.select(`first_name, tokens_balance, pay_per_stream`)
-			.eq('id', session.user.id)
-			.single();
-		profileData = profile;
+		profileData = await fetch(`/api/users/${session.user.id}`).then((res) => res.json());
 		const {
 			data: likedTrackIDs
 		}: {

--- a/app/src/routes/+layout.ts
+++ b/app/src/routes/+layout.ts
@@ -46,6 +46,7 @@ export const load: LayoutLoad = async ({ fetch, data, depends }) => {
 		session,
 		user,
 		profileData: data.profileData,
+		followedArtists: data.followedArtists,
 		likedTracks: data.likedTracks
 	};
 };

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -8,6 +8,9 @@
 	const albumsAndEPs = data.releases.filter(
 		(release) => release.release_type === 'album' || release.release_type === 'ep'
 	);
+
+	const followedArtists = data.artists.filter((artist) => data.followedArtists.includes(artist.id));
+	const otherArtists = data.artists.filter((artist) => !data.followedArtists.includes(artist.id));
 </script>
 
 <svelte:head>
@@ -24,11 +27,29 @@
 <section>
 	<a href="/artists"><h2>Artists</h2></a>
 
-	<ArtistCardGrid artists={data.artists} />
+	{#if followedArtists.length > 0}
+		<div class="artist-card-subsection">
+			<h3>Your followed artists</h3>
+			<ArtistCardGrid artists={followedArtists} />
+		</div>
+	{/if}
+
+	{#if otherArtists.length > 0}
+		<div class="artist-card-subsection">
+			{#if followedArtists.length > 0}<h3>More you might like</h3>{/if}
+			<ArtistCardGrid artists={otherArtists} />
+		</div>
+	{/if}
 </section>
 
 <style>
 	section {
+		margin-bottom: 2rem;
+	}
+	h3 {
+		margin-bottom: 0.5rem;
+	}
+	.artist-card-subsection {
 		margin-bottom: 2rem;
 	}
 </style>

--- a/app/src/routes/account/+page.server.ts
+++ b/app/src/routes/account/+page.server.ts
@@ -1,6 +1,5 @@
 import { fail, redirect } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
-import { TABLES } from '$lib/global/config';
 
 export const load: PageServerLoad = async ({ locals: { safeGetSession } }) => {
 	const { session } = await safeGetSession();
@@ -13,19 +12,25 @@ export const load: PageServerLoad = async ({ locals: { safeGetSession } }) => {
 };
 
 export const actions: Actions = {
-	update: async ({ request, locals: { supabase, safeGetSession } }) => {
+	update: async ({ request, fetch, locals: { safeGetSession } }) => {
 		const formData = await request.formData();
 		const firstName = formData.get('firstName') as string;
 		const payPerStream = formData.get('payPerStream') as string;
 
 		const { session } = await safeGetSession();
 
-		const { error } = await supabase.from(TABLES.users).upsert({
-			id: session?.user.id,
-			first_name: firstName,
-			updated_at: new Date(),
-			pay_per_stream: parseInt(payPerStream)
-		});
+		const { error } = await fetch(`/api/users/${session?.user.id}`, {
+			method: 'PATCH',
+			body: JSON.stringify({
+				updateProfileInfo: {
+					first_name: firstName,
+					pay_per_stream: parseInt(payPerStream)
+				}
+			}),
+			headers: {
+				'Content-Type': 'application/json'
+			}
+		}).then((res) => res.json());
 
 		if (error) {
 			return fail(500, {

--- a/app/src/routes/api/checkout/success/+server.ts
+++ b/app/src/routes/api/checkout/success/+server.ts
@@ -1,7 +1,8 @@
-import { REVENUE_SPLIT, TABLES } from '$lib/global/config';
+import { REVENUE_SPLIT } from '$lib/global/config';
+import { updateUserTokensBalance } from '$lib/global/state.svelte';
 import { type RequestHandler } from '@sveltejs/kit';
 
-export const POST: RequestHandler = async ({ request, locals: { supabase } }) => {
+export const POST: RequestHandler = async ({ request }) => {
 	const requestBody = await request.json();
 
 	if (requestBody.type !== 'checkout.session.completed') {
@@ -26,20 +27,16 @@ export const POST: RequestHandler = async ({ request, locals: { supabase } }) =>
 	}
 
 	const userId: string = stripeSession.metadata.userId;
-	const userTokensBalance = parseInt(stripeSession.metadata.balance);
 	const topUpAmount: number = stripeSession.amount_total;
 	const topUpTokens = Math.round(topUpAmount * REVENUE_SPLIT.artists);
 
-	const { error } = await supabase
-		.from(TABLES.users)
-		.update({
-			tokens_balance: topUpTokens + userTokensBalance
-		})
-		.eq('id', userId);
+	const { error } = await updateUserTokensBalance(userId, topUpTokens, 'add');
+
 	if (error) {
 		console.error('Error updating user balance:', error);
 		return new Response(JSON.stringify({ message: 'Error topping up balance' }), { status: 500 });
 	}
+
 	console.log('User balance updated successfully.');
 
 	return new Response(JSON.stringify({ request }), {

--- a/app/src/routes/api/users/[slug]/+server.ts
+++ b/app/src/routes/api/users/[slug]/+server.ts
@@ -73,4 +73,6 @@ export async function PATCH({ request, params, fetch }) {
 
 		return json({ message: 'User balance updated successfully.' });
 	}
+
+	return json({ error: 'Invalid request' }, { status: 400 });
 }

--- a/app/src/routes/api/users/[slug]/+server.ts
+++ b/app/src/routes/api/users/[slug]/+server.ts
@@ -1,0 +1,76 @@
+import { TABLES } from '$lib/global/config';
+import { supabase } from '$lib/server/supabase';
+import { json } from '@sveltejs/kit';
+import type { UserProfile } from '../../../../../../shared/types';
+
+export async function GET({ params }) {
+	const maybeUserID = params.slug;
+
+	const {
+		data: profile
+	}: {
+		data: UserProfile | null;
+	} = await supabase
+		.from(TABLES.users)
+		.select(`first_name, tokens_balance, pay_per_stream`)
+		.eq('id', maybeUserID)
+		.single();
+
+	if (!profile) {
+		return json({ error: 'User not found' }, { status: 404 });
+	}
+
+	return json(profile);
+}
+
+export async function PATCH({ request, params, fetch }) {
+	const maybeUserID = params.slug;
+
+	const profile: UserProfile | null = await fetch(`/api/users/${maybeUserID}`).then((res) =>
+		res.json()
+	);
+
+	if (!profile) {
+		return json({ error: 'User not found' }, { status: 404 });
+	}
+
+	const { tokens_balance } = profile;
+	const { balanceChange, updateProfileInfo } = await request.json();
+
+	if (updateProfileInfo) {
+		const { first_name, pay_per_stream } = updateProfileInfo;
+		const { error } = await supabase
+			.from(TABLES.users)
+			.update({
+				first_name,
+				pay_per_stream,
+				updated_at: new Date()
+			})
+			.eq('id', maybeUserID);
+
+		if (error) {
+			console.error('Error updating user profile:', error);
+			return json({ error: 'Failed to update user profile' }, { status: 500 });
+		}
+
+		return json({ message: 'User profile updated successfully' });
+	}
+
+	if (balanceChange) {
+		const newBalance = tokens_balance + balanceChange;
+
+		const { error } = await supabase
+			.from(TABLES.users)
+			.update({ tokens_balance: newBalance, updated_at: new Date() })
+			.eq('id', maybeUserID)
+			.select(`first_name, tokens_balance, pay_per_stream`)
+			.single();
+
+		if (error) {
+			console.error('Error updating user profile:', error);
+			return json({ error: 'Failed to update user profile' }, { status: 500 });
+		}
+
+		return json({ message: 'User balance updated successfully.' });
+	}
+}

--- a/app/src/routes/artists/+page.svelte
+++ b/app/src/routes/artists/+page.svelte
@@ -2,6 +2,9 @@
 	import ArtistCardGrid from '$lib/components/ArtistCardGrid.svelte';
 
 	let { data } = $props();
+
+	const followedArtists = data.artists.filter((artist) => data.followedArtists.includes(artist.id));
+	const otherArtists = data.artists.filter((artist) => !data.followedArtists.includes(artist.id));
 </script>
 
 <svelte:head>
@@ -11,8 +14,25 @@
 
 <h2>Artists</h2>
 
-{#if data.artists.length === 0}
-	<p>No artists found.</p>
-{:else}
-	<ArtistCardGrid artists={data.artists} />
+{#if followedArtists.length > 0}
+	<div class="artist-card-subsection">
+		<h3>Your followed artists</h3>
+		<ArtistCardGrid artists={followedArtists} />
+	</div>
 {/if}
+
+{#if otherArtists.length > 0}
+	<div class="artist-card-subsection">
+		{#if followedArtists.length > 0}<h3>More you might like</h3>{/if}
+		<ArtistCardGrid artists={otherArtists} />
+	</div>
+{/if}
+
+<style>
+	h3 {
+		margin-bottom: 0.5rem;
+	}
+	.artist-card-subsection {
+		margin-bottom: 2rem;
+	}
+</style>

--- a/app/src/routes/artists/[slug]/+page.server.ts
+++ b/app/src/routes/artists/[slug]/+page.server.ts
@@ -1,3 +1,5 @@
+import { TABLES } from '$lib/global/config';
+import type { Actions } from '@sveltejs/kit';
 import type { ArtistRaw, ReleaseHydrated } from '../../../../../shared/types';
 
 // TODO: Explore static generation where possible to
@@ -27,4 +29,33 @@ export const load = async ({ params, fetch }) => {
 		artist: matchingArtist,
 		releases: artistReleases
 	};
+};
+
+export const actions: Actions = {
+	toggleFollowedArtist: async ({ request, locals: { supabase, safeGetSession } }) => {
+		const { session } = await safeGetSession();
+		if (session) {
+			const formData = await request.formData();
+			const artistID = formData.get('artistID');
+			if (artistID) {
+				const { data: existingFollowedArtist } = await supabase
+					.from(TABLES.followedArtists)
+					.select('*')
+					.eq('user_id', session.user.id)
+					.eq('artist_id', artistID)
+					.single();
+
+				if (existingFollowedArtist) {
+					await supabase.from(TABLES.followedArtists).delete().eq('artist_id', artistID);
+					console.log(`Artist removed from followed artists: ${artistID}`);
+				} else {
+					await supabase.from(TABLES.followedArtists).insert({
+						user_id: session.user.id,
+						artist_id: artistID
+					});
+					console.log(`Artist added to followed artists: ${artistID}`);
+				}
+			}
+		}
+	}
 };

--- a/app/src/routes/artists/[slug]/+page.svelte
+++ b/app/src/routes/artists/[slug]/+page.svelte
@@ -3,8 +3,12 @@
 	import type { ArtistRaw, ReleaseHydrated } from '../../../../../shared/types';
 	import { makeImageLink } from '$lib/utils';
 	import { sortReleasesByDate } from '../../../../../shared/utils';
+	import { enhance } from '$app/forms';
 
-	let { data }: { data: { artist: ArtistRaw; releases: ReleaseHydrated[] } } = $props();
+	let {
+		data
+	}: { data: { artist: ArtistRaw; releases: ReleaseHydrated[]; followedArtists: string[] } } =
+		$props();
 
 	const { name, bio, website_url, image_ipfs_cid } = data.artist;
 
@@ -13,6 +17,12 @@
 	const lps = releasesSorted.filter((release) => release.release_type === 'album');
 	const eps = releasesSorted.filter((release) => release.release_type === 'ep');
 	const singles = releasesSorted.filter((release) => release.release_type === 'single');
+
+	function handleUpload() {
+		return async ({ update }: { update: () => Promise<void> }) => {
+			await update();
+		};
+	}
 </script>
 
 <svelte:head>
@@ -27,6 +37,13 @@
 <div class="container">
 	<div class="artist-summary-card">
 		<h2>{name}</h2>
+
+		<form action="?/toggleFollowedArtist" method="POST" use:enhance={handleUpload}>
+			<input type="hidden" name="artistID" value={data.artist.id} />
+			<button type="submit"
+				>{data.followedArtists.includes(data.artist.id) ? 'Unfollow' : 'Follow'}</button
+			>
+		</form>
 
 		{#if image_ipfs_cid}
 			<img class="artist-image" src={makeImageLink(image_ipfs_cid, 500)} alt={`Image of ${name}`} />

--- a/app/src/routes/artists/[slug]/+page.svelte
+++ b/app/src/routes/artists/[slug]/+page.svelte
@@ -38,13 +38,6 @@
 	<div class="artist-summary-card">
 		<h2>{name}</h2>
 
-		<form action="?/toggleFollowedArtist" method="POST" use:enhance={handleUpload}>
-			<input type="hidden" name="artistID" value={data.artist.id} />
-			<button type="submit"
-				>{data.followedArtists.includes(data.artist.id) ? 'Unfollow' : 'Follow'}</button
-			>
-		</form>
-
 		{#if image_ipfs_cid}
 			<img class="artist-image" src={makeImageLink(image_ipfs_cid, 500)} alt={`Image of ${name}`} />
 		{/if}
@@ -54,6 +47,21 @@
 		{#if data.artist.website_url}
 			<a href={website_url}>{website_url?.replace('https://', '').replaceAll('/', '')}</a>
 		{/if}
+
+		<hr />
+
+		<div>
+			<div>
+				You are {data.followedArtists.includes(data.artist.id) ? 'following' : 'not following'} this
+				artist.
+			</div>
+			<form action="?/toggleFollowedArtist" method="POST" use:enhance={handleUpload}>
+				<input type="hidden" name="artistID" value={data.artist.id} />
+				<button type="submit"
+					>{data.followedArtists.includes(data.artist.id) ? 'Unfollow' : 'Follow'}</button
+				>
+			</form>
+		</div>
 	</div>
 
 	<div class="artist-music">
@@ -133,6 +141,11 @@
 		font-weight: 500;
 		margin-bottom: 0.5rem;
 		color: gray;
+	}
+	hr {
+		border: none;
+		border-top: 1px solid var(--color-accent);
+		margin: 1rem 0;
 	}
 	@media (min-width: 600px) {
 		h3 {


### PR DESCRIPTION
This allows listeners to follow artists. Implementation is pretty straightforward - toggling the artist's presence in a new 'followed_artists' table. The UI is a bit clunky but seems to work fine locally. Together with #34 Soli already feels a lot more personalised.

<img width="207" height="441" alt="image" src="https://github.com/user-attachments/assets/1975bf00-24ad-49ee-a2e7-6a4175c90bbc" />

<img width="207" height="441" alt="image" src="https://github.com/user-attachments/assets/46ae56a9-eea3-4446-8e39-20d7943fb1c3" />

I also took the opportunity to create a /user endpoint for the API that centralises logic around fetching and editing user data. This is with one eye on #35.
