### PR TITLE
Genre listing pages and links

### DIFF
--- a/app/src/lib/components/tags/TagsGrid.svelte
+++ b/app/src/lib/components/tags/TagsGrid.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	let { slugs, type }: { slugs: string[]; type: 'genres' | 'tags' } = $props();
+</script>
+
+<div class="badge-grid">
+	{#each slugs as slug}
+		<a href="/{type}/{slug}" class="badge">{slug}</a>
+	{/each}
+</div>
+
+<style>
+	.badge-grid {
+		display: flex;
+		flex-direction: row;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+	}
+	.badge {
+		background-color: lightgray;
+		color: #333;
+		padding: 0 0.5rem;
+		border-radius: 4px;
+		width: fit-content;
+		text-decoration: none;
+		font-weight: 500;
+	}
+	.badge:hover {
+		opacity: 0.8;
+	}
+</style>

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import ArtistCardGrid from '$lib/components/ArtistCardGrid.svelte';
 	import ReleaseCardGrid from '$lib/components/ReleaseCardGrid.svelte';
+	import TagsGrid from '$lib/components/tags/TagsGrid.svelte';
 	import type { PageProps } from './$types';
 
 	let { data }: PageProps = $props();
@@ -11,6 +12,9 @@
 
 	const followedArtists = data.artists.filter((artist) => data.followedArtists.includes(artist.id));
 	const otherArtists = data.artists.filter((artist) => !data.followedArtists.includes(artist.id));
+
+	const genres = data.releases.flatMap((release) => release.genres || []);
+	const uniqueGenres = Array.from(new Set(genres));
 </script>
 
 <svelte:head>
@@ -40,6 +44,11 @@
 			<ArtistCardGrid artists={otherArtists} />
 		</div>
 	{/if}
+</section>
+
+<section>
+	<a href="/genres"><h2>Genres</h2></a>
+	<TagsGrid slugs={uniqueGenres} type="genres" />
 </section>
 
 <style>

--- a/app/src/routes/genres/+page.svelte
+++ b/app/src/routes/genres/+page.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import TagsGrid from '$lib/components/tags/TagsGrid.svelte';
+
+	let { data } = $props();
+</script>
+
+<svelte:head>
+	<title>Genres · Soli</title>
+	<meta name="description" content="Browse releases by genre on Soli." />
+</svelte:head>
+
+<h2>Genres</h2>
+<TagsGrid slugs={data.genres} type="genres" />

--- a/app/src/routes/genres/+page.ts
+++ b/app/src/routes/genres/+page.ts
@@ -1,0 +1,13 @@
+import { API_BASE } from '$lib/global/config';
+import type { ReleaseHydrated } from '../../../../shared/types';
+
+export const load = async ({ fetch }) => {
+	const releases: ReleaseHydrated[] = await fetch(`${API_BASE}/releases`).then((res) => res.json());
+
+	const genres = releases.flatMap((release) => release.genres || []);
+	const uniqueGenres = Array.from(new Set(genres));
+
+	return {
+		genres: uniqueGenres
+	};
+};

--- a/app/src/routes/genres/[slug]/+page.svelte
+++ b/app/src/routes/genres/[slug]/+page.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import ReleaseCardGrid from '$lib/components/ReleaseCardGrid.svelte';
+
+	let { data } = $props();
+
+	const capitaliseFirstLetter = (word: string) => {
+		return word.charAt(0).toUpperCase() + word.slice(1);
+	};
+</script>
+
+<svelte:head>
+	<title>{capitaliseFirstLetter(data.genre!)} · Soli</title>
+	<meta name="description" content="Browse releases with the genres '{data.genre}' on Soli." />
+</svelte:head>
+
+<div class="section-link">
+	> <a href="/genres">Genres</a>
+</div>
+
+<h2>{capitaliseFirstLetter(data.genre!)}</h2>
+{#if data.genreReleases}
+	<ReleaseCardGrid releases={data.genreReleases} />
+{/if}
+
+<style>
+	.section-link {
+		margin-bottom: 1rem;
+	}
+</style>

--- a/app/src/routes/genres/[slug]/+page.ts
+++ b/app/src/routes/genres/[slug]/+page.ts
@@ -1,0 +1,23 @@
+import { API_BASE } from '$lib/global/config';
+import type { ReleaseHydrated } from '../../../../../shared/types';
+
+export const load = async ({ params, fetch }) => {
+	const releases: ReleaseHydrated[] = await fetch(`${API_BASE}/releases`).then((res) => res.json());
+
+	const genres = releases.flatMap((release) => release.genres || []);
+	const uniqueGenres = Array.from(new Set(genres));
+
+	if (!uniqueGenres.includes(params.slug)) {
+		return {
+			status: 404,
+			error: new Error('Not Found')
+		};
+	}
+
+	const filteredReleases = releases.filter((release) => release.genres?.includes(params.slug));
+
+	return {
+		genre: params.slug,
+		genreReleases: filteredReleases
+	};
+};

--- a/app/src/routes/releases/[slug]/+page.svelte
+++ b/app/src/routes/releases/[slug]/+page.svelte
@@ -6,6 +6,7 @@
 	import { setActiveSong, userState } from '$lib/global/state.svelte';
 	import ButtonWrapper from '$lib/components/layout/ButtonWrapper.svelte';
 	import { formatReleaseType } from '../../../../../shared/utils';
+	import TagsGrid from '$lib/components/tags/TagsGrid.svelte';
 
 	let {
 		data
@@ -81,10 +82,7 @@
 				release.release_date
 			).toLocaleDateString()}
 		</div>
-
-		{#each release.genres as genre}
-			<div class="genre">{genre}</div>
-		{/each}
+		<TagsGrid slugs={release.genres ?? []} type="genres" />
 	</div>
 </div>
 
@@ -106,15 +104,6 @@
 		aspect-ratio: 1/1;
 		background-color: lightgray;
 		box-shadow: var(--box-shadow);
-	}
-	.genre {
-		display: inline-block;
-		background-color: lightgray;
-		color: #333;
-		padding: 0 0.5rem;
-		margin: 0.5rem 0;
-		border-radius: 4px;
-		width: fit-content;
 	}
 	.play-full-release-button {
 		background-color: var(--color-accent);

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -32,8 +32,8 @@ export interface ReleaseHydrated {
   release_date: string;
   artist_id: string;
   artist_name: string;
-  tags: string[];
-  genres: string[];
+  tags?: string[];
+  genres?: string[];
   tracks: TrackRaw[];
 }
 


### PR DESCRIPTION
This adds genre listing pages that lists all releases with said genre. It also updates the tag badges on release pages to link to the appropriate page.

<img width="369" height="764" alt="image" src="https://github.com/user-attachments/assets/878c1465-3407-4110-b75e-f40851741556" />

Together with search (#12, #49) this has been a lovely case of having the data and API in place so the feature itself is a breeze.