### PR TITLE
Artist PATCH endpoint in API

### DIFF
--- a/api/src/routes/artists/[slug]/+server.ts
+++ b/api/src/routes/artists/[slug]/+server.ts
@@ -21,3 +21,17 @@ export async function GET({ params }) {
 
 	return json(data);
 }
+
+export async function PATCH({ request, params }) {
+	const artistId = params.slug;
+	const body: Partial<ArtistRaw> = await request.json();
+
+	const { data, error } = await supabase.from(TABLES.artists).update(body).eq('id', artistId);
+
+	if (error) {
+		console.error('Error updating artist data:', error);
+		return json({ error: 'Failed to update artist data' }, { status: 500 });
+	}
+
+	return json(data);
+}

--- a/app/src/routes/login/+page.server.ts
+++ b/app/src/routes/login/+page.server.ts
@@ -51,7 +51,7 @@ export const actions: Actions = {
 			return fail(400, {
 				success: false,
 				email,
-				message: `There was an issue, Please contact support.`
+				message: `There was an issue. Sorry about that.`
 			});
 		}
 

--- a/dashboard/src/lib/config.ts
+++ b/dashboard/src/lib/config.ts
@@ -1,4 +1,9 @@
+import { dev } from "$app/environment";
+import { API_DOMAIN, API_LOCAL_PORT } from "../../../shared/config";
+
 export const PUBLIC_SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
 export const PUBLIC_SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export const POWER_USER_ID = import.meta.env.VITE_POWER_USER_ID;
+
+export const API_BASE = dev ? `http://localhost:${API_LOCAL_PORT}` : API_DOMAIN;

--- a/dashboard/src/routes/+page.server.ts
+++ b/dashboard/src/routes/+page.server.ts
@@ -3,6 +3,7 @@ import { pinata } from "$lib/server/pinata";
 import { supabase } from "$lib/server/supabase";
 import { parseFile } from "music-metadata";
 import fs from "fs/promises";
+import { API_BASE } from "$lib/config";
 
 export const actions: Actions = {
   uploadTrack: async ({ request }) => {
@@ -194,16 +195,20 @@ export const actions: Actions = {
         imageCid = upload.cid;
       }
 
-      const { error } = await supabase
-        .from("artists")
-        .update({
+      const response = await fetch(`${API_BASE}/artists/${artistId}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
           bio: artistBio?.trim(),
           website_url: artistWebsite?.trim(),
           image_ipfs_cid: imageCid,
-        })
-        .eq("id", artistId);
+        }),
+      });
 
-      if (error) {
+      if (!response.ok) {
+        const error = await response.json();
         console.error("Error updating artist details:", error);
         return fail(500, {
           error: true,

--- a/dashboard/src/routes/login/+page.server.ts
+++ b/dashboard/src/routes/login/+page.server.ts
@@ -46,29 +46,6 @@ export const actions: Actions = {
       });
     }
 
-    const { error: artistMembersError, data: artistsLinkedToUser } =
-      await supabase
-        .from(TABLES.artistMembers)
-        .select("user_id")
-        .eq("user_id", email);
-
-    if (artistMembersError) {
-      console.error("Error checking user artist links:", artistMembersError);
-      return fail(500, {
-        success: false,
-        email,
-        message: "There was an issue, Please contact support.",
-      });
-    }
-
-    if (artistsLinkedToUser && artistsLinkedToUser.length === 0) {
-      return fail(400, {
-        success: false,
-        email,
-        message: "No artists are linked to this account.",
-      });
-    }
-
     const { error } = await supabase.auth.signInWithOtp({
       email,
       options: {
@@ -80,7 +57,7 @@ export const actions: Actions = {
       return fail(400, {
         success: false,
         email,
-        message: `There was an issue, Please contact support.`,
+        message: `There was an issue. ${error.message}.`,
       });
     }
 


### PR DESCRIPTION
Getting back into the swing of things by moving some of dashboard's functionality to the API where it belongs. More to come. Tested locally and seemed to work fine.

Also removed a shoddily implemented check on whether an email is linked to any artists. Worth revisiting but not important now.