### PR TITLE
API endpoints for dashboard

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"@supabase/ssr": "^0.7.0",
 				"@supabase/supabase-js": "^2.57.4",
+				"music-metadata": "^11.8.3",
 				"pinata": "^2.5.0",
 				"stripe": "^18.5.0"
 			},
@@ -30,6 +31,16 @@
 				"typescript": "^5.9.2",
 				"typescript-eslint": "^8.43.0",
 				"vite": "^7.1.5"
+			}
+		},
+		"node_modules/@borewit/text-codec": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.0.tgz",
+			"integrity": "sha512-X999CKBxGwX8wW+4gFibsbiNdwqmdQEXmUejIWaIqdrHBgS5ARIOOeyiQbHjP9G58xVEPcuvP6VwwH3A0OFTOA==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -1301,6 +1312,30 @@
 				"vite": "^6.3.0 || ^7.0.0"
 			}
 		},
+		"node_modules/@tokenizer/inflate": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
+			"integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"fflate": "^0.8.2",
+				"token-types": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@tokenizer/token": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+			"license": "MIT"
+		},
 		"node_modules/@types/cookie": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -1827,6 +1862,15 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/content-type": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/cookie": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
@@ -1866,10 +1910,9 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-			"dev": true,
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -2307,6 +2350,12 @@
 				}
 			}
 		},
+		"node_modules/fflate": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+			"integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+			"license": "MIT"
+		},
 		"node_modules/file-entry-cache": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2318,6 +2367,24 @@
 			},
 			"engines": {
 				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/file-type": {
+			"version": "21.0.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.0.0.tgz",
+			"integrity": "sha512-ek5xNX2YBYlXhiUXui3D/BXa3LdqPmoLJ7rqEx2bKJ7EAUEfmXgW0Das7Dc6Nr9MvqaOnIqiPV0mZk/r/UpNAg==",
+			"license": "MIT",
+			"dependencies": {
+				"@tokenizer/inflate": "^0.2.7",
+				"strtok3": "^10.2.2",
+				"token-types": "^6.0.0",
+				"uint8array-extras": "^1.4.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
 			}
 		},
 		"node_modules/fill-range": {
@@ -2510,6 +2577,26 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
@@ -2732,6 +2819,15 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/media-typer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2806,8 +2902,37 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/music-metadata": {
+			"version": "11.9.0",
+			"resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-11.9.0.tgz",
+			"integrity": "sha512-J7VqD8FY6KRcm75Fzj86FPsckiD/EdvO5OS3P+JiMf/2krP3TcAseZYfkic6eFeJ0iBhhzcdxgfu8hLW95aXXw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/Borewit"
+				},
+				{
+					"type": "buymeacoffee",
+					"url": "https://buymeacoffee.com/borewit"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@borewit/text-codec": "^0.2.0",
+				"@tokenizer/token": "^0.3.0",
+				"content-type": "^1.0.5",
+				"debug": "^4.4.3",
+				"file-type": "^21.0.0",
+				"media-typer": "^1.1.0",
+				"strtok3": "^10.3.4",
+				"token-types": "^6.1.1",
+				"uint8array-extras": "^1.5.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.11",
@@ -3477,6 +3602,22 @@
 				}
 			}
 		},
+		"node_modules/strtok3": {
+			"version": "10.3.4",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
+			"integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+			"license": "MIT",
+			"dependencies": {
+				"@tokenizer/token": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3599,6 +3740,34 @@
 				"node": ">=8.0"
 			}
 		},
+		"node_modules/token-types": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.1.tgz",
+			"integrity": "sha512-kh9LVIWH5CnL63Ipf0jhlBIy0UsrMj/NJDfpsy1SqOXlLKEVyXXYrnFxFT1yOOYVGBSApeVnjPw/sBz5BfEjAQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@borewit/text-codec": "^0.1.0",
+				"@tokenizer/token": "^0.3.0",
+				"ieee754": "^1.2.1"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/token-types/node_modules/@borewit/text-codec": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.1.1.tgz",
+			"integrity": "sha512-5L/uBxmjaCIX5h8Z+uu+kA9BQLkc/Wl06UGR5ajNRxu+/XjonB5i8JpgFMrPj3LXTCPA0pv8yxUvbUi+QthGGA==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
 		"node_modules/totalist": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -3677,6 +3846,18 @@
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
+		"node_modules/uint8array-extras": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+			"integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/undici-types": {

--- a/api/package.json
+++ b/api/package.json
@@ -35,6 +35,7 @@
 		"@supabase/ssr": "^0.7.0",
 		"@supabase/supabase-js": "^2.57.4",
 		"pinata": "^2.5.0",
-		"stripe": "^18.5.0"
+		"stripe": "^18.5.0",
+		"music-metadata": "^11.8.3"
 	}
 }

--- a/api/src/lib/server/supabase.ts
+++ b/api/src/lib/server/supabase.ts
@@ -1,4 +1,34 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, PostgrestError } from '@supabase/supabase-js';
 import { SUPABASE_URL, SUPABASE_ANON_KEY } from '$env/static/private';
+import { json } from '@sveltejs/kit';
 
 export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+type PostgrestResponse<T> = {
+	data: T | null;
+	error: PostgrestError | null;
+};
+
+export const handlePostgrestQuery = async <T>(
+	queryFunction: () => Promise<PostgrestResponse<T>>,
+	{
+		errorMessage = 'Request failed',
+		transform
+	}: {
+		errorMessage?: string;
+		transform?: (data: T) => T;
+	} = {}
+) => {
+	try {
+		const { data, error } = await queryFunction();
+
+		if (error || !data) {
+			console.error(errorMessage, error);
+			return json({ error: errorMessage }, { status: 500 });
+		}
+		return json(transform ? transform(data) : data);
+	} catch (err) {
+		console.error(errorMessage, err);
+		return json({ error: errorMessage }, { status: 500 });
+	}
+};

--- a/api/src/routes/artists/+server.ts
+++ b/api/src/routes/artists/+server.ts
@@ -1,28 +1,9 @@
 import { TABLES } from '../../../../shared/config';
-import { supabase } from '$lib/server/supabase';
+import { handlePostgrestQuery, supabase } from '$lib/server/supabase';
 import type { ArtistRaw } from '../../../../shared/types';
-import { json } from '@sveltejs/kit';
 
 export async function GET() {
-	const {
-		data,
-		error
-	}: {
-		data: ArtistRaw[] | null;
-		error: Error | null;
-	} = await supabase.from(TABLES.artists).select();
-
-	if (error || !data) {
-		console.error('Error fetching artist data:', error);
-		return json({ error: 'Failed to fetch artist data' }, { status: 500 });
-	}
-
-	// Sort artists by name
-	data.sort((a, b) => {
-		if (a.name < b.name) return -1;
-		if (a.name > b.name) return 1;
-		return 0;
-	});
-
-	return json(data);
+	return handlePostgrestQuery<ArtistRaw[]>(
+		async () => await supabase.from(TABLES.artists).select()
+	);
 }

--- a/api/src/routes/artists/+server.ts
+++ b/api/src/routes/artists/+server.ts
@@ -4,6 +4,9 @@ import type { ArtistRaw } from '../../../../shared/types';
 
 export async function GET() {
 	return handlePostgrestQuery<ArtistRaw[]>(
-		async () => await supabase.from(TABLES.artists).select()
+		async () => await supabase.from(TABLES.artists).select(),
+		{
+			transform: (data) => data.sort((a, b) => a.name.localeCompare(b.name))
+		}
 	);
 }

--- a/api/src/routes/artists/[slug]/+server.ts
+++ b/api/src/routes/artists/[slug]/+server.ts
@@ -1,37 +1,16 @@
 import { TABLES } from '../../../../../shared/config';
-import { supabase } from '$lib/server/supabase';
+import { handlePostgrestQuery, supabase } from '$lib/server/supabase';
 import type { ArtistRaw } from '../../../../../shared/types';
-import { json } from '@sveltejs/kit';
 
 export async function GET({ params }) {
-	const artistId = params.slug;
-
-	const {
-		data,
-		error
-	}: {
-		data: ArtistRaw[] | null;
-		error: Error | null;
-	} = await supabase.from(TABLES.artists).select().eq('id', artistId).single();
-
-	if (error || !data) {
-		console.error('Error fetching artist data:', error);
-		return json({ error: 'Failed to fetch artist data' }, { status: 500 });
-	}
-
-	return json(data);
+	return handlePostgrestQuery<ArtistRaw>(
+		async () => await supabase.from(TABLES.artists).select().eq('id', params.slug).single()
+	);
 }
 
 export async function PATCH({ request, params }) {
-	const artistId = params.slug;
 	const body: Partial<ArtistRaw> = await request.json();
-
-	const { data, error } = await supabase.from(TABLES.artists).update(body).eq('id', artistId);
-
-	if (error) {
-		console.error('Error updating artist data:', error);
-		return json({ error: 'Failed to update artist data' }, { status: 500 });
-	}
-
-	return json(data);
+	return handlePostgrestQuery<ArtistRaw>(
+		async () => await supabase.from(TABLES.artists).update(body).eq('id', params.slug)
+	);
 }

--- a/api/src/routes/artists/[slug]/releases/+server.ts
+++ b/api/src/routes/artists/[slug]/releases/+server.ts
@@ -1,19 +1,9 @@
 import { TABLES } from '../../../../../../shared/config';
-import { supabase } from '$lib/server/supabase';
-import { json } from '@sveltejs/kit';
+import { handlePostgrestQuery, supabase } from '$lib/server/supabase';
+import type { ReleaseHydrated } from '../../../../../../shared/types';
 
 export async function GET({ params }) {
-	const artistId = params.slug;
-
-	const { data, error } = await supabase
-		.from(TABLES.releasesHydrated)
-		.select()
-		.eq('artist_id', artistId);
-
-	if (error || !data) {
-		console.error('Error fetching artist releases:', error);
-		return json({ error: 'Failed to fetch artist releases' }, { status: 500 });
-	}
-
-	return json(data);
+	return handlePostgrestQuery<ReleaseHydrated[]>(
+		async () => await supabase.from(TABLES.releasesHydrated).select().eq('artist_id', params.slug)
+	);
 }

--- a/api/src/routes/releases/+server.ts
+++ b/api/src/routes/releases/+server.ts
@@ -1,35 +1,22 @@
-import { json } from '@sveltejs/kit';
-import { supabase } from '$lib/server/supabase';
+import { handlePostgrestQuery, supabase } from '$lib/server/supabase';
 import { TABLES } from '../../../../shared/config';
-import type { ReleaseHydrated, ReleaseRaw } from '../../../../shared/types';
 import { sortReleasesByDate } from '../../../../shared/utils';
+import type { ReleaseHydrated, ReleaseRaw } from '../../../../shared/types';
 
 export async function GET() {
-	const {
-		data,
-		error
-	}: {
-		data: ReleaseHydrated[] | null;
-		error: Error | null;
-	} = await supabase.from(TABLES.releasesHydrated).select();
-
-	if (error || !data) {
-		console.error('Error fetching artist data:', error);
-		return json({ error: 'Failed to fetch artist data' }, { status: 500 });
-	}
-
-	return json(sortReleasesByDate(data));
+	return handlePostgrestQuery<ReleaseHydrated[]>(
+		async () => await supabase.from(TABLES.releasesHydrated).select(),
+		{
+			errorMessage: 'Failed to fetch artist data',
+			transform: sortReleasesByDate
+		}
+	);
 }
 
 export async function POST({ request }) {
 	const body: Partial<ReleaseRaw> = await request.json();
-
-	const { data, error } = await supabase.from(TABLES.releases).insert(body).select().single();
-
-	if (error || !data) {
-		console.error('Error creating new release:', error);
-		return json({ error: 'Failed to create new release' }, { status: 500 });
-	}
-
-	return json(data);
+	return handlePostgrestQuery<ReleaseRaw>(
+		async () => await supabase.from(TABLES.releases).insert(body).select().single(),
+		{ errorMessage: 'Failed to create new release' }
+	);
 }

--- a/api/src/routes/releases/+server.ts
+++ b/api/src/routes/releases/+server.ts
@@ -2,6 +2,8 @@ import { handlePostgrestQuery, supabase } from '$lib/server/supabase';
 import { TABLES } from '../../../../shared/config';
 import { sortReleasesByDate } from '../../../../shared/utils';
 import type { ReleaseHydrated, ReleaseRaw } from '../../../../shared/types';
+import { pinata } from '$lib/server/pinata';
+import { json } from '@sveltejs/kit';
 
 export async function GET() {
 	return handlePostgrestQuery<ReleaseHydrated[]>(
@@ -14,9 +16,39 @@ export async function GET() {
 }
 
 export async function POST({ request }) {
-	const body: Partial<ReleaseRaw> = await request.json();
-	return handlePostgrestQuery<ReleaseRaw>(
-		async () => await supabase.from(TABLES.releases).insert(body).select().single(),
-		{ errorMessage: 'Failed to create new release' }
-	);
+	try {
+		const formData = await request.formData();
+
+		const releaseArtwork = formData.get('releaseArtwork') as File;
+		const releaseName = formData.get('releaseName') as string;
+		const releaseType = formData.get('releaseType') as string;
+		const artistId = formData.get('artistId') as string;
+		const releaseDate = formData.get('releaseDate') as string;
+		const releaseGenres = formData.get('releaseGenres') as string;
+
+		const upload = await pinata.upload.public
+			.file(releaseArtwork)
+			.name(`'${releaseName}' cover art`)
+			.group(import.meta.env.PINATA_ARTWORK_GROUP);
+
+		return handlePostgrestQuery<ReleaseRaw>(
+			async () =>
+				await supabase
+					.from(TABLES.releases)
+					.insert({
+						title: releaseName,
+						release_type: releaseType,
+						artist_id: artistId,
+						artwork_ipfs_cid: upload.cid,
+						release_date: new Date(releaseDate).toISOString().split('T')[0],
+						genres: releaseGenres ? releaseGenres.split(',').map((genre) => genre.trim()) : []
+					})
+					.select()
+					.single(),
+			{ errorMessage: 'Failed to create new release' }
+		);
+	} catch (error) {
+		console.log(error);
+		return json({ error: 'Internal Server Error' }, { status: 500 });
+	}
 }

--- a/api/src/routes/releases/+server.ts
+++ b/api/src/routes/releases/+server.ts
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
 import { supabase } from '$lib/server/supabase';
 import { TABLES } from '../../../../shared/config';
-import type { ReleaseHydrated } from '../../../../shared/types';
+import type { ReleaseHydrated, ReleaseRaw } from '../../../../shared/types';
 import { sortReleasesByDate } from '../../../../shared/utils';
 
 export async function GET() {
@@ -19,4 +19,17 @@ export async function GET() {
 	}
 
 	return json(sortReleasesByDate(data));
+}
+
+export async function POST({ request }) {
+	const body: Partial<ReleaseRaw> = await request.json();
+
+	const { data, error } = await supabase.from(TABLES.releases).insert(body).select().single();
+
+	if (error || !data) {
+		console.error('Error creating new release:', error);
+		return json({ error: 'Failed to create new release' }, { status: 500 });
+	}
+
+	return json(data);
 }

--- a/api/src/routes/releases/[slug]/+server.ts
+++ b/api/src/routes/releases/[slug]/+server.ts
@@ -1,21 +1,9 @@
 import { TABLES } from '../../../../../shared/config';
-import { supabase } from '$lib/server/supabase';
-import { json } from '@sveltejs/kit';
+import { handlePostgrestQuery, supabase } from '$lib/server/supabase';
 import type { ReleaseHydrated } from '../../../../../shared/types';
 
 export async function GET({ params }) {
-	const {
-		data,
-		error
-	}: {
-		data: ReleaseHydrated | null;
-		error: Error | null;
-	} = await supabase.from(TABLES.releasesHydrated).select().eq('id', params.slug).single();
-
-	if (error || !data) {
-		console.error('Error fetching release data:', error);
-		return json({ error: 'Failed to fetch release data' }, { status: 500 });
-	}
-
-	return json(data);
+	return handlePostgrestQuery<ReleaseHydrated>(
+		async () => await supabase.from(TABLES.releasesHydrated).select().eq('id', params.slug).single()
+	);
 }

--- a/api/src/routes/tracks/+server.ts
+++ b/api/src/routes/tracks/+server.ts
@@ -2,6 +2,7 @@ import { json, type RequestHandler } from '@sveltejs/kit';
 import { supabase } from '$lib/server/supabase';
 import { pinata } from '$lib/server/pinata';
 import { TABLES } from '../../../../shared/config';
+import { formFieldNames } from '../../../../shared/types/forms';
 import { parseFile } from 'music-metadata';
 import fs from 'fs/promises';
 
@@ -25,11 +26,11 @@ export const POST: RequestHandler = async ({ request }) => {
 	try {
 		const formData = await request.formData();
 
-		const file = formData.get('file') as File;
-		const artistId = formData.get('artistId') as string;
-		const title = formData.get('title') as string;
-		const artistName = formData.get('artistName') as string;
-		const artistGroup = formData.get('artistGroup') as string;
+		const file = formData.get(formFieldNames.track.file) as File;
+		const artistId = formData.get(formFieldNames.track.artistID) as string;
+		const title = formData.get(formFieldNames.track.title) as string;
+		const artistName = formData.get(formFieldNames.track.artistName) as string;
+		const artistGroup = formData.get(formFieldNames.track.artistGroup) as string;
 
 		if (!file || !artistId || !title) {
 			return json({ error: 'Missing required fields' }, { status: 400 });
@@ -74,7 +75,7 @@ export const PATCH: RequestHandler = async ({ request }) => {
 		return json({ error: 'Missing required fields' }, { status: 400 });
 	}
 
-	const { error } = await supabase.from('release_tracks').insert({
+	const { error } = await supabase.from(TABLES.releaseTracks).insert({
 		release_id: releaseId,
 		track_id: trackId,
 		track_number: parseInt(trackNumber)

--- a/api/src/routes/tracks/+server.ts
+++ b/api/src/routes/tracks/+server.ts
@@ -66,3 +66,24 @@ export const POST: RequestHandler = async ({ request }) => {
 		return json({ error: 'Upload failed' }, { status: 500 });
 	}
 };
+
+export const PATCH: RequestHandler = async ({ request }) => {
+	const { releaseId, trackId, trackNumber } = await request.json();
+
+	if (!releaseId || !trackId || trackNumber == null) {
+		return json({ error: 'Missing required fields' }, { status: 400 });
+	}
+
+	const { error } = await supabase.from('release_tracks').insert({
+		release_id: releaseId,
+		track_id: trackId,
+		track_number: parseInt(trackNumber)
+	});
+
+	if (error) {
+		console.error('Error inserting track into release:', error);
+		return json({ error: 'Failed to add track to release' }, { status: 500 });
+	}
+
+	return json({ success: true });
+};

--- a/api/src/routes/tracks/+server.ts
+++ b/api/src/routes/tracks/+server.ts
@@ -1,0 +1,68 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { supabase } from '$lib/server/supabase';
+import { pinata } from '$lib/server/pinata';
+import { TABLES } from '../../../../shared/config';
+import { parseFile } from 'music-metadata';
+import fs from 'fs/promises';
+
+const getAudioFileDuration = async (file: File) => {
+	// Write to temporary file system
+	const bytes = await file.arrayBuffer();
+	const buffer = Buffer.from(bytes);
+	const tempPath = `/tmp/${file.name}`;
+
+	await fs.writeFile(tempPath, buffer);
+
+	const metadata = await parseFile(tempPath);
+	const duration = Math.round(metadata.format.duration || 0);
+
+	await fs.unlink(tempPath); // Clean up temporary file
+
+	return duration;
+};
+
+export const POST: RequestHandler = async ({ request }) => {
+	try {
+		const formData = await request.formData();
+
+		const file = formData.get('file') as File;
+		const artistId = formData.get('artistId') as string;
+		const title = formData.get('title') as string;
+		const artistName = formData.get('artistName') as string;
+		const artistGroup = formData.get('artistGroup') as string;
+
+		if (!file || !artistId || !title) {
+			return json({ error: 'Missing required fields' }, { status: 400 });
+		}
+
+		const duration = await getAudioFileDuration(file);
+
+		// Upload to Pinata
+		const upload = await pinata.upload.private
+			.file(file)
+			.name(`${artistName} - ${title}`)
+			.group(artistGroup);
+
+		// Insert into Supabase
+		const { error, data } = await supabase
+			.from(TABLES.tracks)
+			.insert({
+				title,
+				ipfs_cid: upload.cid,
+				artist_id: artistId,
+				duration_seconds: duration
+			})
+			.select()
+			.single();
+
+		if (error) {
+			console.error('Supabase insert failed:', error);
+			return json({ error: 'Failed to save track metadata' }, { status: 500 });
+		}
+
+		return json({ success: true, track: data });
+	} catch (err) {
+		console.error('Upload failed:', err);
+		return json({ error: 'Upload failed' }, { status: 500 });
+	}
+};

--- a/app/src/routes/artists/[slug]/+page.server.ts
+++ b/app/src/routes/artists/[slug]/+page.server.ts
@@ -3,10 +3,6 @@ import type { ArtistRaw } from '../../../../../shared/types';
 import { API_BASE } from '$lib/global/config';
 import { sortReleasesByDate } from '../../../../../shared/utils';
 
-// TODO: Explore static generation where possible to
-// improve performance and keep requests to a minimum.
-// May entail splitting the API into its own thing.
-
 export const load = async ({ params, fetch }) => {
 	const matchingArtist: ArtistRaw = await fetch(`${API_BASE}/artists/${params.slug}`).then(
 		(res) => {

--- a/app/src/routes/artists/[slug]/+page.svelte
+++ b/app/src/routes/artists/[slug]/+page.svelte
@@ -11,6 +11,7 @@
 
 	const { name, bio, website_url, image_ipfs_cid } = $derived(data.artist);
 	const releases = $derived(data.releases);
+	let updatingFollow = $state(false);
 
 	const filterReleasesByType = (type: 'album' | 'ep' | 'single', releases: ReleaseHydrated[]) => {
 		return releases.filter((release) => release.release_type === type);
@@ -20,9 +21,11 @@
 	const eps = $derived(filterReleasesByType('ep', releases));
 	const singles = $derived(filterReleasesByType('single', releases));
 
-	function handleUpload() {
+	function handleUpdate() {
+		updatingFollow = true;
 		return async ({ update }: { update: () => Promise<void> }) => {
 			await update();
+			updatingFollow = false;
 		};
 	}
 </script>
@@ -57,7 +60,7 @@
 				You are {data.followedArtists.includes(data.artist.id) ? 'following' : 'not following'} this
 				artist.
 			</div>
-			<form action="?/toggleFollowedArtist" method="POST" use:enhance={handleUpload}>
+			<form action="?/toggleFollowedArtist" method="POST" use:enhance={handleUpdate}>
 				<input type="hidden" name="artistID" value={data.artist.id} />
 				<input
 					type="hidden"
@@ -65,7 +68,11 @@
 					value={data.followedArtists.includes(data.artist.id) ? 'remove' : 'add'}
 				/>
 				<button type="submit"
-					>{data.followedArtists.includes(data.artist.id) ? 'Unfollow' : 'Follow'}</button
+					>{updatingFollow
+						? 'Updating...'
+						: data.followedArtists.includes(data.artist.id)
+							? 'Unfollow'
+							: 'Follow'}</button
 				>
 			</form>
 		</div>

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -10,7 +10,6 @@
 			"dependencies": {
 				"@supabase/ssr": "^0.7.0",
 				"@supabase/supabase-js": "^2.57.4",
-				"music-metadata": "^11.8.3",
 				"pinata": "^2.5.0"
 			},
 			"devDependencies": {
@@ -21,16 +20,6 @@
 				"svelte-check": "^4.3.1",
 				"typescript": "^5.9.2",
 				"vite": "^7.1.5"
-			}
-		},
-		"node_modules/@borewit/text-codec": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.0.tgz",
-			"integrity": "sha512-X999CKBxGwX8wW+4gFibsbiNdwqmdQEXmUejIWaIqdrHBgS5ARIOOeyiQbHjP9G58xVEPcuvP6VwwH3A0OFTOA==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -1021,30 +1010,6 @@
 				"vite": "^6.3.0 || ^7.0.0"
 			}
 		},
-		"node_modules/@tokenizer/inflate": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
-			"integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.4.0",
-				"fflate": "^0.8.2",
-				"token-types": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
-			}
-		},
-		"node_modules/@tokenizer/token": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-			"license": "MIT"
-		},
 		"node_modules/@types/cookie": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -1142,15 +1107,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/content-type": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/cookie": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
@@ -1165,6 +1121,7 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
 			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -1271,30 +1228,6 @@
 				}
 			}
 		},
-		"node_modules/fflate": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-			"integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-			"license": "MIT"
-		},
-		"node_modules/file-type": {
-			"version": "21.0.0",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.0.0.tgz",
-			"integrity": "sha512-ek5xNX2YBYlXhiUXui3D/BXa3LdqPmoLJ7rqEx2bKJ7EAUEfmXgW0Das7Dc6Nr9MvqaOnIqiPV0mZk/r/UpNAg==",
-			"license": "MIT",
-			"dependencies": {
-				"@tokenizer/inflate": "^0.2.7",
-				"strtok3": "^10.2.2",
-				"token-types": "^6.0.0",
-				"uint8array-extras": "^1.4.0"
-			},
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
-			}
-		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1309,26 +1242,6 @@
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
-		},
-		"node_modules/ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/is-reference": {
 			"version": "3.0.3",
@@ -1367,15 +1280,6 @@
 				"@jridgewell/sourcemap-codec": "^1.5.0"
 			}
 		},
-		"node_modules/media-typer": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/mri": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -1400,37 +1304,8 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/music-metadata": {
-			"version": "11.8.3",
-			"resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-11.8.3.tgz",
-			"integrity": "sha512-Tgiv4MlCgDb6XzelziB1mmL2xeoHls0KTpCm3Z3qr+LfF4mBEpkuc5vNrc927IT5+S5fv+vzStfI+HYC0igDpA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/Borewit"
-				},
-				{
-					"type": "buymeacoffee",
-					"url": "https://buymeacoffee.com/borewit"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@borewit/text-codec": "^0.2.0",
-				"@tokenizer/token": "^0.3.0",
-				"content-type": "^1.0.5",
-				"debug": "^4.4.1",
-				"file-type": "^21.0.0",
-				"media-typer": "^1.1.0",
-				"strtok3": "^10.3.4",
-				"token-types": "^6.1.1",
-				"uint8array-extras": "^1.4.1"
-			},
-			"engines": {
-				"node": ">=18"
-			}
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.11",
@@ -1621,22 +1496,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/strtok3": {
-			"version": "10.3.4",
-			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
-			"integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
-			"license": "MIT",
-			"dependencies": {
-				"@tokenizer/token": "^0.3.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
-			}
-		},
 		"node_modules/svelte": {
 			"version": "5.38.10",
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.38.10.tgz",
@@ -1704,34 +1563,6 @@
 				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
 		},
-		"node_modules/token-types": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.1.tgz",
-			"integrity": "sha512-kh9LVIWH5CnL63Ipf0jhlBIy0UsrMj/NJDfpsy1SqOXlLKEVyXXYrnFxFT1yOOYVGBSApeVnjPw/sBz5BfEjAQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@borewit/text-codec": "^0.1.0",
-				"@tokenizer/token": "^0.3.0",
-				"ieee754": "^1.2.1"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
-			}
-		},
-		"node_modules/token-types/node_modules/@borewit/text-codec": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.1.1.tgz",
-			"integrity": "sha512-5L/uBxmjaCIX5h8Z+uu+kA9BQLkc/Wl06UGR5ajNRxu+/XjonB5i8JpgFMrPj3LXTCPA0pv8yxUvbUi+QthGGA==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
-			}
-		},
 		"node_modules/totalist": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -1760,18 +1591,6 @@
 			},
 			"engines": {
 				"node": ">=14.17"
-			}
-		},
-		"node_modules/uint8array-extras": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
-			"integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/undici-types": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -23,7 +23,6 @@
 	"dependencies": {
 		"@supabase/ssr": "^0.7.0",
 		"@supabase/supabase-js": "^2.57.4",
-		"music-metadata": "^11.8.3",
 		"pinata": "^2.5.0"
 	}
 }

--- a/dashboard/src/lib/config.ts
+++ b/dashboard/src/lib/config.ts
@@ -5,5 +5,6 @@ export const PUBLIC_SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
 export const PUBLIC_SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export const POWER_USER_ID = import.meta.env.VITE_POWER_USER_ID;
+export const PINATA_ARTWORK_GROUP = import.meta.env.PINATA_ARTWORK_GROUP;
 
 export const API_BASE = dev ? `http://localhost:${API_LOCAL_PORT}` : API_DOMAIN;

--- a/dashboard/src/lib/config.ts
+++ b/dashboard/src/lib/config.ts
@@ -3,8 +3,9 @@ import { API_DOMAIN, API_LOCAL_PORT } from "../../../shared/config";
 
 export const PUBLIC_SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
 export const PUBLIC_SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
+export const PINATA_ARTIST_IMAGES_GROUP = import.meta.env
+  .PINATA_ARTIST_IMAGES_GROUP;
 
 export const POWER_USER_ID = import.meta.env.VITE_POWER_USER_ID;
-export const PINATA_ARTWORK_GROUP = import.meta.env.PINATA_ARTWORK_GROUP;
 
 export const API_BASE = dev ? `http://localhost:${API_LOCAL_PORT}` : API_DOMAIN;

--- a/dashboard/src/routes/+page.server.ts
+++ b/dashboard/src/routes/+page.server.ts
@@ -1,70 +1,26 @@
 import { fail, json, redirect, type Actions } from "@sveltejs/kit";
 import { pinata } from "$lib/server/pinata";
 import { supabase } from "$lib/server/supabase";
-import { parseFile } from "music-metadata";
-import fs from "fs/promises";
-import { API_BASE, PINATA_ARTWORK_GROUP } from "$lib/config";
-
-const getAudioFileDuration = async (file: File) => {
-  // Write to temporary file system
-  const bytes = await file.arrayBuffer();
-  const buffer = Buffer.from(bytes);
-  const tempPath = `/tmp/${file.name}`;
-
-  await fs.writeFile(tempPath, buffer);
-
-  const metadata = await parseFile(tempPath);
-  const duration = Math.round(metadata.format.duration || 0);
-
-  await fs.unlink(tempPath); // Clean up temporary file
-
-  return duration;
-};
+import { API_BASE, PINATA_ARTIST_IMAGES_GROUP } from "$lib/config";
 
 export const actions: Actions = {
   uploadTrack: async ({ request }) => {
     try {
       const formData = await request.formData();
-      const uploadedFile = formData?.get("fileToUpload") as File;
-      const uploadedFileTitle = formData?.get("title") as string;
-      const artistName = formData?.get("artistName") as string;
-      const artistId = formData?.get("artistID") as string;
-      const artistGroup = formData?.get("artistGroup") as string;
 
-      if (!uploadedFile.name || uploadedFile.size === 0) {
-        return fail(400, {
-          error: true,
-          message: "You must provide a file to upload",
-        });
-      }
-      if (!artistName || !artistId || !artistGroup) {
-        return fail(400, {
-          error: true,
-          message: "Artist name, ID, and group are required",
-        });
-      }
-
-      const duration = getAudioFileDuration(uploadedFile);
-
-      const upload = await pinata.upload.private
-        .file(uploadedFile)
-        .name(`${artistName} - ${uploadedFileTitle}`)
-        .group(artistGroup);
-
-      const { error } = await supabase.from("tracks").insert({
-        title: uploadedFileTitle,
-        ipfs_cid: upload.cid,
-        artist_id: artistId,
-        duration_seconds: duration,
+      const res = await fetch(`${API_BASE}/tracks`, {
+        method: "POST",
+        body: formData,
       });
 
-      if (error) {
-        console.error("Error inserting track into Supabase:", error);
+      const result = await res.json();
+
+      if (result.error) {
+        console.error("Error inserting track into Supabase:", result.error);
         return fail(500, { error: true, message: "Failed to save track data" });
       }
-
       return {
-        message: `File '${uploadedFile.name} was uploaded successfully`,
+        message: `File was uploaded successfully`,
         status: 200,
       };
     } catch (error) {
@@ -75,49 +31,10 @@ export const actions: Actions = {
   addRelease: async ({ request }) => {
     try {
       const formData = await request.formData();
-      const releaseArtwork = formData.get("releaseArtwork") as File;
-      const releaseName = formData.get("releaseTitle") as string;
-      const artistId = formData.get("artistID") as string;
-      const releaseType = formData.get("releaseType") as string;
-      const releaseDate = formData.get("releaseDate") as string;
-      const releaseGenres = formData.get("releaseGenres") as string;
-
-      if (!releaseName || !artistId) {
-        return fail(400, {
-          error: true,
-          message: "Release name, artist ID, and group are required",
-        });
-      }
-
-      const pinataFileName = `'${releaseName}' cover art`;
-      const upload = await pinata.upload.public
-        .file(releaseArtwork)
-        .name(pinataFileName)
-        .group(PINATA_ARTWORK_GROUP);
-
-      if (!upload || !upload.cid) {
-        console.error("Error uploading artwork to Pinata:", upload);
-        return fail(500, {
-          error: true,
-          message: "Failed to upload artwork to Pinata",
-        });
-      }
 
       const response = await fetch(`${API_BASE}/releases`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          title: releaseName,
-          release_type: releaseType,
-          artist_id: artistId,
-          artwork_ipfs_cid: upload.cid,
-          release_date: new Date(releaseDate).toISOString().split("T")[0],
-          genres: releaseGenres
-            ? releaseGenres.split(",").map((genre) => genre.trim())
-            : [],
-        }),
+        body: formData,
       });
 
       if (!response.ok) {
@@ -193,7 +110,7 @@ export const actions: Actions = {
         const upload = await pinata.upload.public
           .file(artistImage)
           .name(pinataFileName)
-          .group("49d68c8c-764d-467d-b74c-9f64e8bc9647");
+          .group(PINATA_ARTIST_IMAGES_GROUP);
 
         if (!upload || !upload.cid) {
           console.error("Error uploading artist image to Pinata:", upload);

--- a/dashboard/src/routes/+page.server.ts
+++ b/dashboard/src/routes/+page.server.ts
@@ -3,7 +3,23 @@ import { pinata } from "$lib/server/pinata";
 import { supabase } from "$lib/server/supabase";
 import { parseFile } from "music-metadata";
 import fs from "fs/promises";
-import { API_BASE } from "$lib/config";
+import { API_BASE, PINATA_ARTWORK_GROUP } from "$lib/config";
+
+const getAudioFileDuration = async (file: File) => {
+  // Write to temporary file system
+  const bytes = await file.arrayBuffer();
+  const buffer = Buffer.from(bytes);
+  const tempPath = `/tmp/${file.name}`;
+
+  await fs.writeFile(tempPath, buffer);
+
+  const metadata = await parseFile(tempPath);
+  const duration = Math.round(metadata.format.duration || 0);
+
+  await fs.unlink(tempPath); // Clean up temporary file
+
+  return duration;
+};
 
 export const actions: Actions = {
   uploadTrack: async ({ request }) => {
@@ -28,23 +44,11 @@ export const actions: Actions = {
         });
       }
 
-      // Write to temporary file system
-      const bytes = await uploadedFile.arrayBuffer();
-      const buffer = Buffer.from(bytes);
-      const tempPath = `/tmp/${uploadedFile.name}`;
-
-      await fs.writeFile(tempPath, buffer);
-
-      const metadata = await parseFile(tempPath);
-      const duration = Math.round(metadata.format.duration || 0);
-
-      await fs.unlink(tempPath); // Clean up temporary file
-
-      const pinataFileName = `${artistName} - ${uploadedFileTitle}`;
+      const duration = getAudioFileDuration(uploadedFile);
 
       const upload = await pinata.upload.private
         .file(uploadedFile)
-        .name(pinataFileName)
+        .name(`${artistName} - ${uploadedFileTitle}`)
         .group(artistGroup);
 
       const { error } = await supabase.from("tracks").insert({
@@ -59,11 +63,13 @@ export const actions: Actions = {
         return fail(500, { error: true, message: "Failed to save track data" });
       }
 
-      const url = await pinata.gateways.public.convert(upload.cid);
-      return { url, filename: uploadedFile.name, status: 200 };
+      return {
+        message: `File '${uploadedFile.name} was uploaded successfully`,
+        status: 200,
+      };
     } catch (error) {
       console.log(error);
-      return json({ error: "Internal Server Error" }, { status: 500 });
+      return json({ error: "Internal Server Error", status: 500 });
     }
   },
   addRelease: async ({ request }) => {
@@ -87,8 +93,7 @@ export const actions: Actions = {
       const upload = await pinata.upload.public
         .file(releaseArtwork)
         .name(pinataFileName)
-        // TODO: Move this to environment variable
-        .group("f4ffc1db-8d43-4fee-890b-950b692b8ca1");
+        .group(PINATA_ARTWORK_GROUP);
 
       if (!upload || !upload.cid) {
         console.error("Error uploading artwork to Pinata:", upload);

--- a/dashboard/src/routes/+page.server.ts
+++ b/dashboard/src/routes/+page.server.ts
@@ -58,21 +58,20 @@ export const actions: Actions = {
       const trackId = formData.get("trackID") as string;
       const trackNumber = formData.get("trackNumber") as string;
 
-      if (!releaseId || !trackId) {
-        return fail(400, {
-          error: true,
-          message: "Release ID and track ID are required",
-        });
-      }
-
-      const { error } = await supabase.from("release_tracks").insert({
-        release_id: releaseId,
-        track_id: trackId,
-        track_number: parseInt(trackNumber) || 0, // Default to 0 if not provided
+      const response = await fetch(`${API_BASE}/tracks`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          releaseId,
+          trackId,
+          trackNumber,
+        }),
       });
 
-      if (error) {
-        console.error("Error inserting track into release:", error);
+      if (!response.ok) {
+        console.error("Error adding track to release:", response);
         return fail(500, {
           error: true,
           message: "Failed to add track to release",

--- a/dashboard/src/routes/+page.server.ts
+++ b/dashboard/src/routes/+page.server.ts
@@ -98,19 +98,25 @@ export const actions: Actions = {
         });
       }
 
-      const { error } = await supabase.from("releases").insert({
-        title: releaseName,
-        release_type: releaseType,
-        artist_id: artistId,
-        artwork_ipfs_cid: upload.cid,
-        release_date: new Date(releaseDate).toISOString().split("T")[0],
-        genres: releaseGenres
-          ? releaseGenres.split(",").map((genre) => genre.trim())
-          : [],
+      const response = await fetch(`${API_BASE}/releases`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          title: releaseName,
+          release_type: releaseType,
+          artist_id: artistId,
+          artwork_ipfs_cid: upload.cid,
+          release_date: new Date(releaseDate).toISOString().split("T")[0],
+          genres: releaseGenres
+            ? releaseGenres.split(",").map((genre) => genre.trim())
+            : [],
+        }),
       });
 
-      if (error) {
-        console.error("Error inserting release into Supabase:", error);
+      if (!response.ok) {
+        console.error("Error inserting release into Supabase:", response);
         return fail(500, {
           error: true,
           message: "Failed to save release data",

--- a/dashboard/src/routes/+page.server.ts
+++ b/dashboard/src/routes/+page.server.ts
@@ -1,6 +1,5 @@
 import { fail, json, redirect, type Actions } from "@sveltejs/kit";
 import { pinata } from "$lib/server/pinata";
-import { supabase } from "$lib/server/supabase";
 import { API_BASE, PINATA_ARTIST_IMAGES_GROUP } from "$lib/config";
 
 export const actions: Actions = {

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -8,6 +8,7 @@
     StreamLog,
     TrackRaw,
   } from "../../../shared/types";
+  import { formFieldNames } from "../../../shared/types/forms";
   import { dashboardState } from "$lib/state.svelte";
   import Card from "$lib/components/Card.svelte";
   import ReleaseInfo from "$lib/components/ReleaseInfo.svelte";
@@ -118,26 +119,36 @@
               action="?/uploadTrack"
               use:enhance={handleUpload}
             >
-              <input type="file" id="file" name="file" accept=".mp3" />
+              <input
+                type="file"
+                id="file"
+                name={formFieldNames.track.file}
+                accept=".mp3"
+              />
               <label for="file">Choose an MP3 file</label>
-              <input type="text" name="title" placeholder="Title" required />
               <input
                 type="text"
-                name="artistName"
+                name={formFieldNames.track.title}
+                placeholder="Title"
+                required
+              />
+              <input
+                type="text"
+                name={formFieldNames.track.artistName}
                 value={activeArtist.name}
                 class="hidden"
                 required
               />
               <input
                 type="text"
-                name="artistId"
+                name={formFieldNames.track.artistID}
                 value={activeArtist.id}
                 class="hidden"
                 required
               />
               <input
                 type="text"
-                name="artistGroup"
+                name={formFieldNames.track.artistGroup}
                 value={activeArtist.pinata_group_id}
                 class="hidden"
                 required

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -118,7 +118,7 @@
               action="?/uploadTrack"
               use:enhance={handleUpload}
             >
-              <input type="file" id="file" name="fileToUpload" accept=".mp3" />
+              <input type="file" id="file" name="file" accept=".mp3" />
               <label for="file">Choose an MP3 file</label>
               <input type="text" name="title" placeholder="Title" required />
               <input
@@ -130,7 +130,7 @@
               />
               <input
                 type="text"
-                name="artistID"
+                name="artistId"
                 value={activeArtist.id}
                 class="hidden"
                 required
@@ -167,7 +167,7 @@
               <label for="releaseArtwork">Choose release artwork</label>
               <input
                 type="text"
-                name="releaseTitle"
+                name="releaseName"
                 placeholder="Release Title"
                 required
               />
@@ -179,7 +179,7 @@
               </select>
               <input
                 type="text"
-                name="artistID"
+                name="artistId"
                 value={activeArtist.id}
                 class="hidden"
                 required

--- a/shared/config/index.ts
+++ b/shared/config/index.ts
@@ -18,6 +18,7 @@ export const TABLES = {
   artistMembers: "artist_members",
   tracks: "tracks",
   releaseTracks: "release_tracks",
+  releases: "releases",
   releasesHydrated: "hydrated_releases",
   streams: "streams",
   betaUsers: "beta-users",

--- a/shared/types/forms.ts
+++ b/shared/types/forms.ts
@@ -1,0 +1,9 @@
+export const formFieldNames = {
+  track: {
+    file: "file",
+    artistID: "artistID",
+    title: "title",
+    artistName: "artistName",
+    artistGroup: "artistGroup",
+  },
+};


### PR DESCRIPTION
This moves some logic from the dashboard to the API and adds more endpoints so musicians can upload and edit music. The focus has been on the following paths:

- /releases
- /tracks

I've done some refactoring as part of the PR as well, abstracting some of the code around Supabase queries to cut down on duplicate code. Have tested locally and seems to work nicely.

Also need to configure the API so that only the dashboard can hit certain endpoints/functions.
