### PR TITLE
Tighter track upload UI and errors

### DIFF
--- a/api/src/routes/tracks/+server.ts
+++ b/api/src/routes/tracks/+server.ts
@@ -32,19 +32,33 @@ export const POST: RequestHandler = async ({ request }) => {
 		const artistGroup = formData.get('artistGroup') as string;
 
 		if (!file || !artistId || !title) {
-			return json({ error: 'Missing required fields' }, { status: 400 });
+			return json({ error: 'Missing required fields', fields: { file: !!file, artistId: !!artistId, title: !!title } }, { status: 400 });
 		}
 
-		const duration = await getAudioFileDuration(file);
+		// Get duration
+		let duration: number;
+		try {
+			duration = await getAudioFileDuration(file);
+		} catch (err) {
+			console.error('Failed to parse audio metadata:', err);
+			return json({ error: 'Failed to read audio file — it may be corrupt or an unsupported format', detail: String(err) }, { status: 400 });
+		}
 
 		// Upload to Pinata
-		const upload = await pinata.upload.private
-			.file(file)
-			.name(`${artistName} - ${title}`)
-			.group(artistGroup);
+		let upload;
+		try {
+			upload = await pinata.upload.private
+				.file(file)
+				.name(`${artistName} - ${title}`)
+				.group(artistGroup);
+			console.log('Pinata upload successful:', upload);
+		} catch (err) {
+			console.error('Pinata upload failed:', err);
+			return json({ error: 'Failed to upload to IPFS', detail: String(err) }, { status: 500 });
+		}
 
-		// Insert into Supabase
-		const { error, data } = await supabase
+		// Insert metadata into Supabase
+		const { error: insertError, data } = await supabase
 			.from(TABLES.tracks)
 			.insert({
 				title,
@@ -55,27 +69,36 @@ export const POST: RequestHandler = async ({ request }) => {
 			.select()
 			.single();
 
-		const bucketFileName = `${data.id}.mp3`;
+		if (insertError) {
+			console.error('Supabase row insert failed:', insertError);
+			return json({ error: 'Failed to save track metadata', detail: insertError.message }, { status: 500 });
+		}
 
-		const { error: supabaseError } = await supabase.storage
+		console.log('Supabase insert successful:', data);
+
+		// Upload file to Supabase storage
+		const bucketFileName = `${data.id}.mp3`;
+		const { error: storageError } = await supabase.storage
 			.from('tracks')
 			.upload(bucketFileName, file);
 
-		if (error) {
-			console.error('Supabase row insert failed:', error);
-			return json({ error: 'Failed to save track metadata' }, { status: 500 });
+		if (storageError) {
+			console.error('Supabase storage upload failed:', storageError);
+			// Row was inserted but file upload failed — flag this clearly
+			return json({
+				error: 'Track metadata saved but file upload to storage failed',
+				detail: storageError.message,
+				trackId: data.id
+			}, { status: 500 });
 		}
 
-		// Uploading to Supabase as well as a backup
-		if (supabaseError) {
-			console.error('Supabase file upload failed:', supabaseError);
-			return json({ error: 'Failed to upload track file' }, { status: 500 });
-		}
+		console.log('Supabase storage upload successful:', bucketFileName);
 
 		return json({ success: true, track: data });
+
 	} catch (err) {
-		console.error('Upload failed:', err);
-		return json({ error: 'Upload failed' }, { status: 500 });
+		console.error('Unexpected error during upload:', err);
+		return json({ error: 'Unexpected error during upload', detail: String(err) }, { status: 500 });
 	}
 };
 

--- a/dashboard/src/lib/components/forms/AddReleaseForm.svelte
+++ b/dashboard/src/lib/components/forms/AddReleaseForm.svelte
@@ -11,15 +11,15 @@
 	<input {...addRelease.fields.artistId.as('hidden', artistId)} />
 	<label>
 		Title
-		<input {...addRelease.fields.releaseName.as('text')} />
+		<input {...addRelease.fields.releaseName.as('text')} disabled={!!addRelease.pending} />
 	</label>
 	<label>
 		Artwork image file
-		<input {...addRelease.fields.releaseArtwork.as('file')} />
+		<input {...addRelease.fields.releaseArtwork.as('file')} disabled={!!addRelease.pending} />
 	</label>
 	<label>
 		Type
-		<select {...addRelease.fields.releaseType.as('select')}>
+		<select {...addRelease.fields.releaseType.as('select')} disabled={!!addRelease.pending}>
 			<option value="album">Album</option>
 			<option value="ep">EP</option>
 			<option value="single">Single</option>
@@ -27,7 +27,11 @@
 	</label>
 	<label>
 		Genres
-		<select {...addRelease.fields.releaseGenres.as('select multiple')} multiple>
+		<select
+			{...addRelease.fields.releaseGenres.as('select multiple')}
+			multiple
+			disabled={!!addRelease.pending}
+		>
 			{#each genres as genre}
 				<option value={genre}>{genre}</option>
 			{/each}
@@ -35,7 +39,9 @@
 	</label>
 	<label>
 		Release date
-		<input {...addRelease.fields.releaseDate.as('date')} />
+		<input {...addRelease.fields.releaseDate.as('date')} disabled={!!addRelease.pending} />
 	</label>
-	<button type="submit">Add Release</button>
+	<button type="submit" disabled={!!addRelease.pending}>
+		{addRelease.pending ? 'Adding...' : 'Add Release'}
+	</button>
 </form>

--- a/dashboard/src/lib/components/forms/AddTrackToReleaseForm.svelte
+++ b/dashboard/src/lib/components/forms/AddTrackToReleaseForm.svelte
@@ -17,7 +17,10 @@
 <form {...addTrackToRelease}>
 	<label>
 		Release
-		<select {...addTrackToRelease.fields.releaseId.as('select')}>
+		<select
+			{...addTrackToRelease.fields.releaseId.as('select')}
+			disabled={!!addTrackToRelease.pending}
+		>
 			{#each releases as release}
 				<option value={release.id}>{release.title}</option>
 			{/each}
@@ -25,7 +28,10 @@
 	</label>
 	<label>
 		Track
-		<select {...addTrackToRelease.fields.trackId.as('select')}>
+		<select
+			{...addTrackToRelease.fields.trackId.as('select')}
+			disabled={!!addTrackToRelease.pending}
+		>
 			{#each tracks as track}
 				<option value={track.id}>{track.title}</option>
 			{/each}
@@ -33,7 +39,12 @@
 	</label>
 	<label>
 		Track number
-		<input {...addTrackToRelease.fields.trackNumber.as('number')} />
+		<input
+			{...addTrackToRelease.fields.trackNumber.as('number')}
+			disabled={!!addTrackToRelease.pending}
+		/>
 	</label>
-	<button type="submit"> Add to Release </button>
+	<button type="submit" disabled={!!addTrackToRelease.pending}>
+		{addTrackToRelease.pending ? 'Adding...' : 'Add to Release'}
+	</button>
 </form>

--- a/dashboard/src/lib/components/forms/ArtistProfileForm.svelte
+++ b/dashboard/src/lib/components/forms/ArtistProfileForm.svelte
@@ -27,23 +27,34 @@
 	{/if}
 	<label>
 		Change profile image
-		<input {...updateArtistDetails.fields.artistImageNew.as('file')} />
+		<input
+			{...updateArtistDetails.fields.artistImageNew.as('file')}
+			disabled={!!updateArtistDetails.pending}
+		/>
 	</label>
 	<label>
 		Bio
-		<textarea {...updateArtistDetails.fields.artistBio.as('text')} value={artistBio}></textarea>
+		<textarea
+			{...updateArtistDetails.fields.artistBio.as('text')}
+			value={artistBio}
+			disabled={!!updateArtistDetails.pending}
+		></textarea>
 	</label>
 	{#each updateArtistDetails.fields.artistBio.issues() as issue}
 		<div class="issue">{issue.message}</div>
 	{/each}
 	<label>
 		Website
-		<input {...updateArtistDetails.fields.artistWebsite.as('text')} value={artistWebsite} />
+		<input
+			{...updateArtistDetails.fields.artistWebsite.as('text')}
+			value={artistWebsite}
+			disabled={!!updateArtistDetails.pending}
+		/>
 	</label>
 	{#each updateArtistDetails.fields.artistWebsite.issues() as issue}
 		<div class="issue">{issue.message}</div>
 	{/each}
-	<button type="submit" disabled={!!updateArtistDetails.pending} data-sveltekit-reload
-		>Update profile</button
-	>
+	<button type="submit" disabled={!!updateArtistDetails.pending} data-sveltekit-reload>
+		{updateArtistDetails.pending ? 'Updating...' : 'Update profile'}
+	</button>
 </form>

--- a/dashboard/src/lib/components/forms/UploadTrackForm.svelte
+++ b/dashboard/src/lib/components/forms/UploadTrackForm.svelte
@@ -13,14 +13,16 @@
 <form {...uploadTrack} enctype="multipart/form-data">
 	<label>
 		Track audio file
-		<input {...uploadTrack.fields.file.as('file')} />
+		<input {...uploadTrack.fields.file.as('file')} disabled={!!uploadTrack.pending} />
 	</label>
 	<label>
 		Title
-		<input {...uploadTrack.fields.title.as('text')} />
+		<input {...uploadTrack.fields.title.as('text')} disabled={!!uploadTrack.pending} />
 	</label>
 	<input {...uploadTrack.fields.artistId.as('hidden', artistId)} />
 	<input {...uploadTrack.fields.artistName.as('hidden', artistName)} />
 	<input {...uploadTrack.fields.artistGroup.as('hidden', artistGroup)} />
-	<button type="submit">Upload Track</button>
+	<button type="submit" disabled={!!uploadTrack.pending}>
+		{uploadTrack.pending ? 'Uploading...' : 'Upload Track'}
+	</button>
 </form>


### PR DESCRIPTION
While trying to debug a 500 error around track uploads in the dashboard I wasn't able to replicate the issue but thought I could at least make the failures more meaningful.

Have also tried to make the form behaviour a bit easier on the eye, with 'Loading...' states and disabled inputs when a submission is in flight.