### PR TITLE
Adjust path exemptions

### DIFF
--- a/api/src/hooks.server.ts
+++ b/api/src/hooks.server.ts
@@ -23,7 +23,9 @@ export const handle: Handle = async ({ resolve, event }) => {
 		return response;
 	}
 
-	if ((!origin || !domainsWithAccessToAPI.includes(origin)) && !dev) {
+	const originIsAllowed = !origin || domainsWithAccessToAPI.includes(origin);
+
+	if (!originIsAllowed && !dev) {
 		console.error(`Unauthorized access attempt from origin: ${origin}`);
 		return new Response('Unauthorised', { status: 401 });
 	}

--- a/dashboard/src/hooks.server.ts
+++ b/dashboard/src/hooks.server.ts
@@ -45,9 +45,10 @@ const authGuard: Handle = async ({ event, resolve }) => {
 	event.locals.session = session;
 	event.locals.user = user;
 
-	if (!event.locals.session && !['/login'].some((path) => event.url.pathname.startsWith(path))) {
+	if (!event.locals.session && event.url.pathname === '/') {
 		redirect(303, '/login');
 	}
+
 	return resolve(event);
 };
 


### PR DESCRIPTION
I _think_ this resolves an issue reported by artists where form submissions - i.e. remote functions - were being patchy in the dashboard. By chance I was able to replicate the issue and got this error in the console:

```
https://dashboard.soli.network/_app/remote/1dbr7xx/uploadTrack 500 (Internal Server Error)
```
The dashboard had quite an aggressive auth guard so the /_app/remote prefix was being redirected to /login in the dashboard's `hooks.server.ts`.

This rejigs the path exemptions to still redirect as desired while allowing remote functions to do their thing.