### PR TITLE
Homepage spotlight slot and general TLC

### DIFF
--- a/app/src/lib/components/home/FeaturedArtistCard.svelte
+++ b/app/src/lib/components/home/FeaturedArtistCard.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import { makeImageLink } from '$lib/utils';
+	import type { Artist } from '../../../../../shared/types/core';
+
+	const { artist }: { artist: Artist } = $props();
+</script>
+
+<a href={`/artists/${artist.id}`}>
+	<div class="featured-artist-card">
+		<img
+			src={artist.image_ipfs_cid ? makeImageLink(artist.image_ipfs_cid, 1000) : ''}
+			alt={artist.name}
+		/>
+		<h2>{artist.name}</h2>
+	</div>
+</a>
+
+<style>
+	a {
+		text-decoration: none;
+		color: inherit;
+	}
+	a:hover {
+		opacity: 0.8;
+	}
+	.featured-artist-card {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		position: relative;
+	}
+	img {
+		aspect-ratio: 1 / 1;
+		object-fit: cover;
+		border: 2px solid var(--color-accent);
+		border-radius: 8px;
+		background-color: var(--color-accent);
+	}
+	h2 {
+		position: absolute;
+		bottom: 1rem;
+		left: 1rem;
+		color: white;
+		text-shadow: 0 0 5px rgba(0, 0, 0, 0.7);
+		margin: 0;
+	}
+	/* Table up */
+	@media (min-width: 600px) {
+		img {
+			aspect-ratio: 16 / 9;
+		}
+	}
+</style>

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import CircleCard from '$lib/components/CircleCard.svelte';
 	import GridWrapper from '$lib/components/GridWrapper.svelte';
+	import FeaturedArtistCard from '$lib/components/home/FeaturedArtistCard.svelte';
 	import WelcomeExplainer from '$lib/components/layout/WelcomeExplainer.svelte';
 	import ReleaseCard from '$lib/components/ReleaseCard.svelte';
 	import TagsGrid from '$lib/components/tags/TagsGrid.svelte';
@@ -19,15 +20,42 @@
 		};
 	} = $props();
 
-	const albumsAndEPs = data.releases.filter(
-		(release) => release.release_type === 'album' || release.release_type === 'ep'
+	const recentAlbums = $derived(
+		data.releases.filter((release) => release.release_type === 'album').slice(0, 6)
+	);
+	const recentEPs = $derived(
+		data.releases.filter((release) => release.release_type === 'ep').slice(0, 6)
+	);
+	const recentSingles = $derived(
+		data.releases.filter((release) => release.release_type === 'single').slice(0, 6)
 	);
 
-	const followedArtists = data.artists.filter((artist) => data.followedArtists.includes(artist.id));
-	const otherArtists = data.artists.filter((artist) => !data.followedArtists.includes(artist.id));
+	const followedArtists = $derived(
+		data.artists.filter((artist) => data.followedArtists.includes(artist.id))
+	);
+	const otherArtists = $derived(
+		data.artists.filter((artist) => !data.followedArtists.includes(artist.id))
+	);
 
-	const genres = data.releases.flatMap((release) => release.genres || []);
-	const uniqueGenres = Array.from(new Set(genres));
+	const genres = $derived(data.releases.flatMap((release) => release.genres || []));
+	const uniqueGenres = $derived(Array.from(new Set(genres)));
+
+	const featuredArtist = $derived(otherArtists[Math.floor(Math.random() * otherArtists.length)]);
+
+	const latestReleases = $derived([
+		{
+			label: 'Albums',
+			releases: recentAlbums
+		},
+		{
+			label: 'EPs',
+			releases: recentEPs
+		},
+		{
+			label: 'Singles',
+			releases: recentSingles
+		}
+	]);
 </script>
 
 <svelte:head>
@@ -41,81 +69,109 @@
 	</section>
 {/if}
 
-<section>
-	<a href="/artists"><h2>Artists</h2></a>
+<div class="content">
+	<section>
+		<a href="/artists"><h2>Artists</h2></a>
 
-	{#if followedArtists.length > 0}
-		<div class="artist-card-subsection">
-			<h3>Your followed artists</h3>
-			<GridWrapper>
-				{#each followedArtists as artist}
-					<CircleCard
-						name={artist.name}
-						image={artist.image_ipfs_cid ? makeImageLink(artist.image_ipfs_cid, 200) : undefined}
-						link={`/artists/${artist.id}`}
-					/>
-				{/each}
-			</GridWrapper>
+		<div class="subsection">
+			<h3>Spotlight</h3>
+			<FeaturedArtistCard artist={featuredArtist} />
 		</div>
-	{/if}
 
-	{#if otherArtists.length > 0}
-		<div class="artist-card-subsection">
-			{#if followedArtists.length > 0}<h3>More you might like</h3>{/if}
-			<GridWrapper>
-				{#each otherArtists as artist}
-					<CircleCard
-						name={artist.name}
-						image={artist.image_ipfs_cid ? makeImageLink(artist.image_ipfs_cid, 200) : undefined}
-						link={`/artists/${artist.id}`}
-					/>
-				{/each}
-			</GridWrapper>
+		{#if followedArtists.length > 0}
+			<div class="subsection">
+				<h3>Your followed artists</h3>
+				<GridWrapper>
+					{#each followedArtists as artist}
+						<CircleCard
+							name={artist.name}
+							image={artist.image_ipfs_cid ? makeImageLink(artist.image_ipfs_cid, 200) : undefined}
+							link={`/artists/${artist.id}`}
+						/>
+					{/each}
+				</GridWrapper>
+			</div>
+		{/if}
+
+		{#if otherArtists.length > 0}
+			<div class="subsection">
+				{#if followedArtists.length > 0}<h3>More you might like</h3>{/if}
+				<GridWrapper>
+					{#each otherArtists.filter((artist) => artist.id !== featuredArtist.id) as artist}
+						<CircleCard
+							name={artist.name}
+							image={artist.image_ipfs_cid ? makeImageLink(artist.image_ipfs_cid, 200) : undefined}
+							link={`/artists/${artist.id}`}
+						/>
+					{/each}
+				</GridWrapper>
+			</div>
+		{/if}
+	</section>
+
+	<section>
+		<div class="section-header">
+			<h2>Recent releases</h2>
+			<a href="/releases">See all</a>
 		</div>
-	{/if}
-</section>
 
-<section>
-	<a href="/releases"><h2>Releases</h2></a>
-
-	<GridWrapper gridItemSize="150px" gridGap="20px">
-		{#each albumsAndEPs as release}
-			<ReleaseCard
-				link={`/releases/${release.id}`}
-				name={release.title}
-				artist={release.artist.name}
-				coverArt={makeImageLink(release.artwork_ipfs_cid, 200)}
-			/>
+		{#each latestReleases as { label, releases }}
+			<div class="subsection">
+				<h3>{label}</h3>
+				<GridWrapper gridItemSize="150px" gridGap="20px">
+					{#each releases as release}
+						<ReleaseCard
+							link={`/releases/${release.id}`}
+							name={release.title}
+							artist={release.artist.name}
+							coverArt={makeImageLink(release.artwork_ipfs_cid, 200)}
+						/>
+					{/each}
+				</GridWrapper>
+			</div>
 		{/each}
-	</GridWrapper>
-</section>
+	</section>
 
-<section>
-	<a href="/labels"><h2>Labels</h2></a>
-	<GridWrapper>
-		{#each data.labels as label}
-			<CircleCard
-				name={label.name}
-				image={label.image_cid ? makeImageLink(label.image_cid, 200) : undefined}
-				link={`/labels/${label.id}`}
-			/>
-		{/each}
-	</GridWrapper>
-</section>
+	<section>
+		<a href="/labels"><h2>Labels</h2></a>
+		<GridWrapper>
+			{#each data.labels as label}
+				<CircleCard
+					name={label.name}
+					image={label.image_cid ? makeImageLink(label.image_cid, 200) : undefined}
+					link={`/labels/${label.id}`}
+				/>
+			{/each}
+		</GridWrapper>
+	</section>
 
-<section>
-	<a href="/genres"><h2>Genres</h2></a>
-	<TagsGrid slugs={uniqueGenres} type="genres" />
-</section>
+	<section>
+		<a href="/genres"><h2>Genres</h2></a>
+		<TagsGrid slugs={uniqueGenres} type="genres" />
+	</section>
+</div>
 
 <style>
+	.content {
+		margin: 0 auto;
+		max-width: 1200px;
+	}
 	section {
 		margin-bottom: 2rem;
+	}
+	.section-header {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+		margin-bottom: 1rem;
+	}
+	.section-header h2 {
+		margin: 0;
 	}
 	h3 {
 		margin-bottom: 0.5rem;
 	}
-	.artist-card-subsection {
+	.subsection {
 		margin-bottom: 2rem;
 	}
 </style>


### PR DESCRIPTION
Fumez suggested a kind of featured spot for artists (just randomly selected from artists not currently followed), and I wound up doing some tidying for the homepage too - splitting different release types, capping the number that are shown and linking to see more.

| Before  | After  |
|---|---|
| <img width="456" height="3372" alt="image" src="https://github.com/user-attachments/assets/f64a300a-5f92-48a6-bb18-48605a7d0460" />  | <img width="456" height="4402" alt="image" src="https://github.com/user-attachments/assets/2f26fa46-1d9b-4a6b-9f87-fb586b0375a9" />  |

Much livelier!