### PR TITLE
Add label view to dashboard

### DIFF
--- a/api/src/routes/labels/[slug]/+server.ts
+++ b/api/src/routes/labels/[slug]/+server.ts
@@ -1,10 +1,51 @@
+import { pinata } from '$lib/server/pinata';
 import { handlePostgrestQuery, supabase } from '$lib/server/supabase';
+import { json } from '@sveltejs/kit';
 import { TABLES } from '../../../../../shared/config';
 import type { Label } from '../../../../../shared/types/core';
 
 export async function GET({ params }) {
 	return handlePostgrestQuery<Label>(
-		async () => await supabase.from(TABLES.labels).select().eq('id', params.slug).single(),
+		async () => await supabase.from(TABLES.labelsRich).select().eq('id', params.slug).single(),
 		{ errorMessage: 'Failed to fetch label' }
 	);
+}
+
+export async function PATCH({ request, params }) {
+	const formData = await request.formData();
+
+	const labelImageNew = formData.get('labelImageNew') as File;
+	const labelName = formData.get('labelName') as string;
+	const labelDescription = formData.get('labelDescription') as string;
+	const labelWebsite = formData.get('labelWebsite') as string;
+
+	let imageCid: string | undefined;
+
+	if (labelImageNew && labelImageNew.size > 0) {
+		const pinataFileName = `${labelName} profile image`;
+		const upload = await pinata.upload.public
+			.file(labelImageNew)
+			.name(pinataFileName)
+			.group(import.meta.env.PINATA_LABEL_IMAGES_GROUP);
+
+		if (!upload || !upload.cid) {
+			console.error('Error uploading label image to Pinata:', upload);
+		}
+		// TODO: Delete old label image if it exists
+		imageCid = upload.cid;
+	}
+
+	const { error } = await supabase
+		.from(TABLES.labels)
+		.update({
+			name: labelName,
+			description: labelDescription,
+			website_url: labelWebsite,
+			image_cid: imageCid
+		})
+		.eq('id', params.slug);
+	if (error) {
+		return json({ error: 'Failed to update label details' }, { status: 500 });
+	}
+	return json({ success: true });
 }

--- a/api/src/routes/users/[slug]/labels/+server.ts
+++ b/api/src/routes/users/[slug]/labels/+server.ts
@@ -1,0 +1,37 @@
+import { TABLES } from '../../../../../../shared/config';
+import { supabase } from '$lib/server/supabase';
+import { json } from '@sveltejs/kit';
+import type { Label } from '../../../../../../shared/types/core';
+
+export async function GET({ params }) {
+	const userId = params.slug;
+
+	const { data: relatedLabelData, error } = await supabase
+		.from(TABLES.labelMembers)
+		.select('label_id')
+		.eq('user_id', userId);
+
+	if (error) {
+		console.error('Error fetching user labels:', error);
+		return json({ error: 'Failed to fetch user labels' }, { status: 500 });
+	}
+
+	const {
+		data: connectedLabels,
+		error: labelError
+	}: {
+		data: Label[] | null;
+		error: Error | null;
+	} = await supabase
+		.from(TABLES.labels)
+		.select('*')
+		.in(
+			'id',
+			relatedLabelData.map((u) => u.label_id)
+		);
+	if (labelError) {
+		console.error('Error fetching connected labels:', labelError);
+		return json({ error: 'Failed to fetch connected labels' }, { status: 500 });
+	}
+	return json(connectedLabels);
+}

--- a/api/src/routes/users/[slug]/labels/+server.ts
+++ b/api/src/routes/users/[slug]/labels/+server.ts
@@ -2,6 +2,7 @@ import { TABLES } from '../../../../../../shared/config';
 import { supabase } from '$lib/server/supabase';
 import { json } from '@sveltejs/kit';
 import type { Label } from '../../../../../../shared/types/core';
+import type { LabelHydrated } from '../../../../../../shared/types/hydrated';
 
 export async function GET({ params }) {
 	const userId = params.slug;
@@ -20,10 +21,10 @@ export async function GET({ params }) {
 		data: connectedLabels,
 		error: labelError
 	}: {
-		data: Label[] | null;
+		data: LabelHydrated[] | null;
 		error: Error | null;
 	} = await supabase
-		.from(TABLES.labels)
+		.from(TABLES.labelsRich)
 		.select('*')
 		.in(
 			'id',

--- a/app/src/lib/components/audio-player/AudioPlayer.svelte
+++ b/app/src/lib/components/audio-player/AudioPlayer.svelte
@@ -17,7 +17,6 @@
 	import TrackLikeButton from '../releases/TrackLikeButton.svelte';
 	import { fade, slide } from 'svelte/transition';
 	import SpinningRecord from './SpinningRecord.svelte';
-	import { is } from 'zod/locales';
 
 	let {
 		userId,

--- a/dashboard/src/lib/components/forms/LabelProfileForm.svelte
+++ b/dashboard/src/lib/components/forms/LabelProfileForm.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import { updateLabelDetails } from '$lib/remote-functions/label.remote';
+	import { makeImageLink } from '$lib/utils';
+
+	let {
+		labelId,
+		labelName,
+		currentLabelImageCID,
+		labelDescription,
+		labelWebsite
+	}: {
+		labelId: string;
+		labelName: string;
+		currentLabelImageCID?: string;
+		labelDescription?: string;
+		labelWebsite?: string;
+	} = $props();
+</script>
+
+<form {...updateLabelDetails.enhance(({ submit }) => submit())} enctype="multipart/form-data">
+	<input {...updateLabelDetails.fields.labelId.as('hidden', labelId)} />
+	<input {...updateLabelDetails.fields.labelName.as('hidden', labelName)} />
+	{#if currentLabelImageCID}
+		<div>
+			<img src={makeImageLink(currentLabelImageCID, 300)} alt="Current Label Profile" />
+		</div>
+	{/if}
+	<label>
+		Change profile image
+		<input
+			{...updateLabelDetails.fields.labelImageNew.as('file')}
+			disabled={!!updateLabelDetails.pending}
+		/>
+	</label>
+	<label>
+		Description
+		<textarea
+			{...updateLabelDetails.fields.labelDescription.as('text')}
+			value={labelDescription}
+			disabled={!!updateLabelDetails.pending}
+		></textarea>
+	</label>
+	{#each updateLabelDetails.fields.labelDescription.issues() as issue}
+		<div class="issue">{issue.message}</div>
+	{/each}
+	<label>
+		Website
+		<input
+			{...updateLabelDetails.fields.labelWebsite.as('text')}
+			value={labelWebsite}
+			disabled={!!updateLabelDetails.pending}
+		/>
+	</label>
+	{#each updateLabelDetails.fields.labelWebsite.issues() as issue}
+		<div class="issue">{issue.message}</div>
+	{/each}
+	<button type="submit" disabled={!!updateLabelDetails.pending} data-sveltekit-reload>
+		{updateLabelDetails.pending ? 'Updating...' : 'Update profile'}
+	</button>
+</form>

--- a/dashboard/src/lib/components/views/label/LabelView.svelte
+++ b/dashboard/src/lib/components/views/label/LabelView.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import LabelProfileForm from '$lib/components/forms/LabelProfileForm.svelte';
+	import type { LabelHydrated } from '../../../../../../shared/types/hydrated';
+
+	let { activeLabel }: { activeLabel: LabelHydrated } = $props();
+</script>
+
+<div class="label-profile">
+	<h2>Profile</h2>
+	<h3>{activeLabel.name}</h3>
+	<LabelProfileForm
+		labelId={activeLabel.id}
+		labelName={activeLabel.name}
+		currentLabelImageCID={activeLabel.image_cid}
+		labelDescription={activeLabel.description}
+		labelWebsite={activeLabel.website_url}
+	/>
+</div>
+
+<style>
+	.label-profile {
+		width: 100%;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 1rem;
+	}
+</style>

--- a/dashboard/src/lib/config.ts
+++ b/dashboard/src/lib/config.ts
@@ -2,6 +2,8 @@ import { dev } from '$app/environment';
 import {
 	API_DOMAIN,
 	API_LOCAL_PORT,
+	APP_DOMAIN,
+	APP_LOCAL_PORT,
 	DASHBOARD_DOMAIN,
 	DASHBOARD_LOCAL_PORT
 } from '../../../shared/config';
@@ -10,10 +12,10 @@ export const PUBLIC_SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
 export const PUBLIC_SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export const API_BASE = dev ? `http://localhost:${API_LOCAL_PORT}` : API_DOMAIN;
-
-export const DOMAIN_BASE = dev ? `http://localhost:${DASHBOARD_LOCAL_PORT}` : DASHBOARD_DOMAIN;
+export const APP_BASE = dev ? `http://localhost:${APP_LOCAL_PORT}` : APP_DOMAIN;
+export const DASHBOARD_BASE = dev ? `http://localhost:${DASHBOARD_LOCAL_PORT}` : DASHBOARD_DOMAIN;
 
 export const REQUEST_HEADER_BOILERPLATE = {
 	'Content-Type': 'application/json',
-	origin: DOMAIN_BASE
+	origin: DASHBOARD_BASE
 };

--- a/dashboard/src/lib/remote-functions/artist.remote.ts
+++ b/dashboard/src/lib/remote-functions/artist.remote.ts
@@ -1,5 +1,5 @@
-import { form, getRequestEvent, query } from '$app/server';
-import { API_BASE, DOMAIN_BASE, REQUEST_HEADER_BOILERPLATE } from '$lib/config';
+import { form, query } from '$app/server';
+import { API_BASE, DASHBOARD_BASE, REQUEST_HEADER_BOILERPLATE } from '$lib/config';
 import * as z from 'zod';
 import type { Track } from '../../../../shared/types/core';
 import { sortReleasesByDate } from '../../../../shared/utils';
@@ -25,7 +25,7 @@ export const updateArtistDetails = form(ArtistDetailsForm, async (data) => {
 	await fetch(`${API_BASE}/artists/${data.artistId}`, {
 		method: 'PATCH',
 		headers: {
-			origin: DOMAIN_BASE
+			origin: DASHBOARD_BASE
 		},
 		body: formData
 	});

--- a/dashboard/src/lib/remote-functions/label.remote.ts
+++ b/dashboard/src/lib/remote-functions/label.remote.ts
@@ -1,0 +1,29 @@
+import { form } from '$app/server';
+import { API_BASE, DASHBOARD_BASE } from '$lib/config';
+import * as z from 'zod';
+
+const LabelDetailsForm = z.object({
+	labelId: z.string(),
+	labelName: z.string().min(1),
+	labelImageNew: z.instanceof(File).optional(),
+	labelDescription: z.string().max(1000).optional(),
+	labelWebsite: z.string().optional()
+});
+
+export const updateLabelDetails = form(LabelDetailsForm, async (data) => {
+	const formData = new FormData();
+	if (data.labelImageNew) {
+		formData.append('labelImageNew', data.labelImageNew);
+	}
+	formData.append('labelName', data.labelName);
+	formData.append('labelId', data.labelId);
+	formData.append('labelDescription', data.labelDescription || '');
+	formData.append('labelWebsite', data.labelWebsite || '');
+	await fetch(`${API_BASE}/labels/${data.labelId}`, {
+		method: 'PATCH',
+		headers: {
+			origin: DASHBOARD_BASE
+		},
+		body: formData
+	});
+});

--- a/dashboard/src/lib/remote-functions/music.remote.ts
+++ b/dashboard/src/lib/remote-functions/music.remote.ts
@@ -1,5 +1,5 @@
 import { form, query } from '$app/server';
-import { API_BASE, DOMAIN_BASE, REQUEST_HEADER_BOILERPLATE } from '$lib/config';
+import { API_BASE, DASHBOARD_BASE, REQUEST_HEADER_BOILERPLATE } from '$lib/config';
 import * as z from 'zod';
 
 const AddReleaseForm = z.object({
@@ -35,7 +35,7 @@ export const addRelease = form(AddReleaseForm, async (data) => {
 	await fetch(`${API_BASE}/releases`, {
 		method: 'POST',
 		headers: {
-			origin: DOMAIN_BASE
+			origin: DASHBOARD_BASE
 		},
 		body: formData
 	});
@@ -53,7 +53,7 @@ export const uploadTrack = form(UploadTrackForm, async (data) => {
 	await fetch(`${API_BASE}/tracks`, {
 		method: 'POST',
 		headers: {
-			origin: DOMAIN_BASE
+			origin: DASHBOARD_BASE
 		},
 		body: formData
 	});

--- a/dashboard/src/lib/state.svelte.ts
+++ b/dashboard/src/lib/state.svelte.ts
@@ -1,10 +1,12 @@
-import type { Artist } from '../../../shared/types/core';
+import type { Artist, Label } from '../../../shared/types/core';
 
 export const dashboardState: {
 	activeArtist: Artist | null;
+	activeLabel: Label | null;
 	activeSection: DashboardSectionId;
 } = $state({
 	activeArtist: null,
+	activeLabel: null,
 	activeSection: 'profile'
 });
 

--- a/dashboard/src/lib/state.svelte.ts
+++ b/dashboard/src/lib/state.svelte.ts
@@ -1,8 +1,9 @@
 import type { Artist, Label } from '../../../shared/types/core';
+import type { LabelHydrated } from '../../../shared/types/hydrated';
 
 export const dashboardState: {
 	activeArtist: Artist | null;
-	activeLabel: Label | null;
+	activeLabel: LabelHydrated | null;
 	activeSection: DashboardSectionId;
 } = $state({
 	activeArtist: null,
@@ -10,4 +11,4 @@ export const dashboardState: {
 	activeSection: 'profile'
 });
 
-export type DashboardSectionId = 'profile' | 'music' | 'stats' | 'payouts';
+export type DashboardSectionId = 'profile' | 'music' | 'stats' | 'payouts' | 'artists';

--- a/dashboard/src/routes/+layout.server.ts
+++ b/dashboard/src/routes/+layout.server.ts
@@ -1,6 +1,7 @@
 import type { LayoutServerLoad } from './$types';
 import type { ArtistHydrated } from '../../../shared/types/hydrated';
 import { API_BASE, REQUEST_HEADER_BOILERPLATE } from '$lib/config';
+import type { Label } from '../../../shared/types/core';
 
 export const load: LayoutServerLoad = async ({ locals: { safeGetSession }, cookies }) => {
 	const { session, user } = await safeGetSession();
@@ -29,10 +30,16 @@ export const load: LayoutServerLoad = async ({ locals: { safeGetSession }, cooki
 		return 0;
 	});
 
+	const connectedLabels: Label[] = await fetch(`${API_BASE}/users/${userID}/labels`, {
+		method: 'GET',
+		headers: REQUEST_HEADER_BOILERPLATE
+	}).then((res) => res.json());
+
 	return {
 		session,
 		user,
 		cookies: cookies.getAll(),
-		artists: connectedArtists
+		artists: connectedArtists,
+		labels: connectedLabels
 	};
 };

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -9,7 +9,7 @@
 
 	let { children, data } = $props();
 
-	let { supabase, session, artists } = $derived(data);
+	let { supabase, session, artists, labels } = $derived(data);
 
 	onMount(() => {
 		const { data } = supabase.auth.onAuthStateChange((_, newSession) => {
@@ -56,6 +56,24 @@
 				</select>
 			{:else}
 				<li>No artists found.</li>
+			{/if}
+			{#if labels}
+				<h3>Your linked labels</h3>
+				<select
+					class="label-selector"
+					onchange={(e) => {
+						const selectedId = (e.target as HTMLSelectElement).value;
+						dashboardState.activeLabel = labels.find((l) => l.id === selectedId) || null;
+						dashboardState.activeSection = 'profile';
+					}}
+				>
+					<option value="" selected>Select a label</option>
+					{#each labels as label}
+						<option value={label.id}>
+							{label.name}
+						</option>
+					{/each}
+				</select>
 			{/if}
 			{#if dashboardState.activeArtist}
 				<hr />

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -20,10 +20,15 @@
 		return () => data.subscription.unsubscribe();
 	});
 
-	const dashboardSections: { id: DashboardSectionId; name: string }[] = [
+	const artistDashboardSections: { id: DashboardSectionId; name: string }[] = [
 		{ id: 'profile', name: 'Profile' },
 		{ id: 'music', name: 'Music' },
 		{ id: 'stats', name: 'Stats' }
+	];
+
+	const labelDashboardSections: { id: DashboardSectionId; name: string }[] = [
+		{ id: 'profile', name: 'Profile' },
+		{ id: 'artists', name: 'Artists' }
 	];
 </script>
 
@@ -36,8 +41,8 @@
 		<div class="side-panel">
 			<h1>Soli • Dashboard</h1>
 			<hr />
-			<div>User: {session?.user?.email}</div>
-			{#if artists}
+			<div>User: {session.user.email}</div>
+			{#if artists && artists.length > 0}
 				<h3>Your linked artists</h3>
 				<select
 					class="artist-selector"
@@ -57,7 +62,7 @@
 			{:else}
 				<li>No artists found.</li>
 			{/if}
-			{#if labels}
+			{#if labels && labels.length > 0}
 				<h3>Your linked labels</h3>
 				<select
 					class="label-selector"
@@ -77,7 +82,29 @@
 			{/if}
 			{#if dashboardState.activeArtist}
 				<hr />
-				{#each dashboardSections as section}
+				{#each artistDashboardSections as section}
+					<div
+						class="section-selector"
+						class:active={dashboardState.activeSection === section.id}
+						role="button"
+						onclick={() => {
+							dashboardState.activeSection = section.id;
+						}}
+						onkeydown={(e) => {
+							if (e.key === 'Enter' || e.key === ' ') {
+								dashboardState.activeSection = section.id;
+							}
+						}}
+						aria-label={`${section.name} Section`}
+						tabindex="0"
+					>
+						{section.name}
+					</div>
+				{/each}
+			{/if}
+			{#if dashboardState.activeLabel}
+				<hr />
+				{#each labelDashboardSections as section}
 					<div
 						class="section-selector"
 						class:active={dashboardState.activeSection === section.id}

--- a/dashboard/src/routes/+layout.ts
+++ b/dashboard/src/routes/+layout.ts
@@ -29,6 +29,7 @@ export const load: LayoutLoad = async ({ fetch, data, depends }) => {
 		supabase,
 		session: data.session ?? null,
 		user: data.user,
-		artists: data.artists
+		artists: data.artists,
+		labels: data.labels
 	};
 };

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -8,7 +8,8 @@
 	import MusicView from '$lib/components/views/music/MusicView.svelte';
 	import { getArtistReleases, getArtistTracks } from '$lib/remote-functions/artist.remote';
 	import { getArtistStreams } from '$lib/remote-functions/stats.remote';
-	import { makeImageLink } from '$lib/utils';
+	import LabelView from '$lib/components/views/label/LabelView.svelte';
+	import { APP_BASE } from '$lib/config';
 
 	let {
 		data
@@ -59,20 +60,22 @@
 			<StatsView streams={activeArtistStreams} />
 		{/if}
 	{:else if dashboardState.activeLabel}
-		<div>
-			<h2>{dashboardState.activeLabel.name}</h2>
-			{#if dashboardState.activeLabel.image_cid}
-				<img
-					src={makeImageLink(dashboardState.activeLabel.image_cid, 500)}
-					alt="{dashboardState.activeLabel.name} logo"
-					class="label-logo"
-				/>
-			{/if}
-			<p>{dashboardState.activeLabel.description}</p>
-			<a href={dashboardState.activeLabel.website_url} target="_blank" rel="noopener noreferrer"
-				>{dashboardState.activeLabel.website_url}</a
-			>
-		</div>
+		{#if dashboardState.activeSection === 'profile'}
+			<LabelView activeLabel={dashboardState.activeLabel} />
+		{:else if dashboardState.activeSection === 'artists'}
+			<div class="label-artists">
+				<h2>Artists on your label</h2>
+				{#if dashboardState.activeLabel.artists.length > 0}
+					<ul>
+						{#each dashboardState.activeLabel.artists as artist}
+							<li><a href={`${APP_BASE}/artist/${artist.id}`} target="_blank">{artist.name}</a></li>
+						{/each}
+					</ul>
+				{:else}
+					<p>You don't have any artists linked to your label yet.</p>
+				{/if}
+			</div>
+		{/if}
 	{:else}
 		<div class="no-selection">
 			<h2>Welcome to your dashboard</h2>

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -8,6 +8,7 @@
 	import MusicView from '$lib/components/views/music/MusicView.svelte';
 	import { getArtistReleases, getArtistTracks } from '$lib/remote-functions/artist.remote';
 	import { getArtistStreams } from '$lib/remote-functions/stats.remote';
+	import { makeImageLink } from '$lib/utils';
 
 	let {
 		data
@@ -57,7 +58,25 @@
 		{:else if dashboardState.activeSection === 'stats'}
 			<StatsView streams={activeArtistStreams} />
 		{/if}
+	{:else if dashboardState.activeLabel}
+		<div>
+			<h2>{dashboardState.activeLabel.name}</h2>
+			{#if dashboardState.activeLabel.image_cid}
+				<img
+					src={makeImageLink(dashboardState.activeLabel.image_cid, 500)}
+					alt="{dashboardState.activeLabel.name} logo"
+					class="label-logo"
+				/>
+			{/if}
+			<p>{dashboardState.activeLabel.description}</p>
+			<a href={dashboardState.activeLabel.website_url} target="_blank" rel="noopener noreferrer"
+				>{dashboardState.activeLabel.website_url}</a
+			>
+		</div>
 	{:else}
-		<div>Select an artist to manage their releases and songs.</div>
+		<div class="no-selection">
+			<h2>Welcome to your dashboard</h2>
+			<p>Please select an artist or label from the sidebar to get started.</p>
+		</div>
 	{/if}
 </div>

--- a/shared/config/index.ts
+++ b/shared/config/index.ts
@@ -35,5 +35,6 @@ export const TABLES = {
 	mixtapes: 'mixtapes',
 	mixtapesRich: 'mixtapes_rich',
 	mixtapeTracks: 'mixtape_tracks',
-	labels: 'labels'
+	labels: 'labels',
+	labelMembers: 'label_members'
 };

--- a/shared/config/index.ts
+++ b/shared/config/index.ts
@@ -36,5 +36,6 @@ export const TABLES = {
 	mixtapesRich: 'mixtapes_rich',
 	mixtapeTracks: 'mixtape_tracks',
 	labels: 'labels',
+	labelsRich: 'labels_rich',
 	labelMembers: 'label_members'
 };

--- a/shared/types/hydrated.ts
+++ b/shared/types/hydrated.ts
@@ -22,3 +22,7 @@ export interface CollectionHydrated extends Collection {
 export interface MixtapeHydrated extends Mixtape {
 	tracks: TrackHydrated[];
 }
+
+export interface LabelHydrated extends Label {
+	artists: Artist[];
+}


### PR DESCRIPTION
This introduces labels to the dashboard, allowing as a first pass for profile details like logo, description, and website to be updated.

<img width="1910" height="979" alt="image" src="https://github.com/user-attachments/assets/1d304986-2223-476b-8f6a-8394f343f5f6" />

Users can also see a list of their artists, though that's as far as functionality goes for now. A clunky first pass but it's a start and something to build on.