### PR TITLE
Don't charge people to listen to their own music

### DIFF
--- a/api/src/routes/releases/[slug]/+server.ts
+++ b/api/src/routes/releases/[slug]/+server.ts
@@ -4,6 +4,10 @@ import { TABLES } from '../../../../../shared/config';
 import type { ReleaseHydrated } from '../../../../../shared/types/hydrated';
 
 export async function GET({ params }) {
+	const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+	if (!uuidRegex.test(params.slug)) {
+		return json({ error: 'Invalid release ID' }, { status: 400 });
+	}
 	return handlePostgrestQuery<ReleaseHydrated>(
 		async () => await supabase.from(TABLES.releasesRich).select().eq('id', params.slug).single(),
 		{ errorMessage: 'Failed to fetch release' }

--- a/api/src/routes/streams/+server.ts
+++ b/api/src/routes/streams/+server.ts
@@ -4,7 +4,7 @@ import { supabase } from '$lib/server/supabase';
 export async function POST({ request }) {
 	const { streamId, userId, artistId, trackId, tokensUsed } = await request.json();
 
-	if (!streamId || !userId || !artistId || !trackId || !tokensUsed) {
+	if (!streamId || !userId || !artistId || !trackId || tokensUsed == null) {
 		return new Response('Missing required fields', { status: 400 });
 	}
 

--- a/app/src/lib/components/audio-player/AudioPlayer.svelte
+++ b/app/src/lib/components/audio-player/AudioPlayer.svelte
@@ -6,13 +6,18 @@
 	import { setActiveSong } from '$lib/utils/audio-playback';
 	import { STREAM_THRESHOLD_SECONDS } from '../../../../../shared/config';
 	import type { Track } from '../../../../../shared/types/core';
-	import type { ReleaseHydrated, TrackHydrated } from '../../../../../shared/types/hydrated';
+	import type {
+		ArtistHydrated,
+		ReleaseHydrated,
+		TrackHydrated
+	} from '../../../../../shared/types/hydrated';
 	import ButtonWrapper from '../layout/ButtonWrapper.svelte';
 	import Icon from '../layout/Icon.svelte';
 	import Logo from '../layout/Logo.svelte';
 	import TrackLikeButton from '../releases/TrackLikeButton.svelte';
 	import { fade, slide } from 'svelte/transition';
 	import SpinningRecord from './SpinningRecord.svelte';
+	import { is } from 'zod/locales';
 
 	let {
 		userId,
@@ -21,7 +26,8 @@
 		track,
 		release,
 		songUrl,
-		likedTracks
+		likedTracks,
+		linkedArtists
 	}: {
 		userId: string;
 		userBalance: number;
@@ -30,6 +36,7 @@
 		release: ReleaseHydrated;
 		songUrl: string;
 		likedTracks: TrackHydrated[];
+		linkedArtists: ArtistHydrated[];
 	} = $props();
 
 	let fullPage = $state(false);
@@ -39,7 +46,11 @@
 	let listenedSeconds = $state(0);
 	let lastTime = $state(0);
 
-	const onTimeUpdate = () => {
+	let artistIsLinkedToUser = $derived(
+		linkedArtists.some((linkedArtist) => linkedArtist.id === release.artist_id)
+	);
+
+	const onTimeUpdate = async () => {
 		if (!audioElement || charged) return;
 
 		const delta = audioElement.currentTime - lastTime;
@@ -52,8 +63,12 @@
 
 		if (listenedSeconds >= STREAM_THRESHOLD_SECONDS) {
 			charged = true;
-			charge();
-			showPaymentPopup();
+			const chargeResult = await chargeForStreamAndLog(artistIsLinkedToUser);
+			if (chargeResult.success && !artistIsLinkedToUser) {
+				showPaymentPopup();
+			} else if (!chargeResult.success) {
+				console.error('Error charging for stream');
+			}
 		}
 	};
 
@@ -64,20 +79,39 @@
 		}, 3000);
 	};
 
-	const charge = async () => {
-		await updateUserTokensBalance({
-			userId,
-			tokens: userPayPerStream,
-			addOrSubtract: 'subtract'
-		}).run();
+	const chargeForStreamAndLog = async (isFreebie: boolean) => {
+		if (isFreebie) {
+			const logResult = await logStream({
+				streamId: userState.activeStreamSessionId!,
+				userId,
+				artistId: release.artist_id,
+				trackId: track.id,
+				tokensUsed: 0
+			}).run();
 
-		await logStream({
-			streamId: userState.activeStreamSessionId!,
-			userId,
-			artistId: release.artist_id,
-			trackId: track.id,
-			tokensUsed: userPayPerStream
-		}).run();
+			if (!logResult.success) console.error('Error logging stream');
+			return { success: logResult.success };
+		}
+
+		const [balanceUpdateResult, logResult] = await Promise.all([
+			updateUserTokensBalance({
+				userId,
+				tokens: userPayPerStream,
+				addOrSubtract: 'subtract'
+			}).run(),
+			logStream({
+				streamId: userState.activeStreamSessionId!,
+				userId,
+				artistId: release.artist_id,
+				trackId: track.id,
+				tokensUsed: userPayPerStream
+			}).run()
+		]);
+
+		if (!balanceUpdateResult.success) console.error('Error updating user balance');
+		if (!logResult.success) console.error('Error logging stream');
+
+		return { success: balanceUpdateResult.success && logResult.success };
 	};
 
 	$effect(() => {

--- a/app/src/lib/components/layout/StickyNav.svelte
+++ b/app/src/lib/components/layout/StickyNav.svelte
@@ -2,7 +2,7 @@
 	import { userState } from '$lib/global/state.svelte';
 	import { getHydratedRelease } from '$lib/remote-functions/releases.remote';
 	import type { Listener } from '../../../../../shared/types/core';
-	import type { TrackHydrated } from '../../../../../shared/types/hydrated';
+	import type { ArtistHydrated, TrackHydrated } from '../../../../../shared/types/hydrated';
 	import AudioPlayer from '../audio-player/AudioPlayer.svelte';
 	import ButtonWrapper from './ButtonWrapper.svelte';
 	import Icon, { type IconKey } from './Icon.svelte';
@@ -12,12 +12,14 @@
 		searchIsOpen = $bindable(),
 		userId,
 		userProfileData,
-		userLikedTracks
+		userLikedTracks,
+		userLinkedArtists
 	}: {
 		searchIsOpen: boolean;
 		userId: string;
 		userProfileData: Listener;
 		userLikedTracks: TrackHydrated[];
+		userLinkedArtists: ArtistHydrated[];
 	} = $props();
 
 	let currentReleaseHydrated = $derived(
@@ -44,6 +46,7 @@
 			release={currentReleaseHydrated}
 			songUrl={userState.activeSongUrl}
 			likedTracks={userLikedTracks}
+			linkedArtists={userLinkedArtists}
 		/>
 	{/if}
 	<div class="sticky-nav-buttons">

--- a/app/src/lib/global/state.svelte.ts
+++ b/app/src/lib/global/state.svelte.ts
@@ -1,6 +1,7 @@
 import type { Session } from '@supabase/supabase-js';
 import type { Mixtape, Release, Track, Listener } from '../../../../shared/types/core';
 import type {
+	ArtistHydrated,
 	CollectionHydrated,
 	MixtapeHydrated,
 	TrackHydrated
@@ -23,6 +24,7 @@ export interface UserData {
 	likedTracks: TrackHydrated[];
 	mixtapes: Mixtape[];
 	followedArtists: string[];
+	linkedArtists: ArtistHydrated[];
 }
 
 export const userState: UserState = $state({

--- a/app/src/lib/remote-functions/listening.remote.ts
+++ b/app/src/lib/remote-functions/listening.remote.ts
@@ -24,8 +24,10 @@ export const logStream = query(
 		});
 		if (status === 200) {
 			console.log('Stream logged successfully');
+			return { success: true };
 		} else {
 			console.error('Error logging stream:', status);
+			return { success: false };
 		}
 	}
 );

--- a/app/src/lib/remote-functions/user.remote.ts
+++ b/app/src/lib/remote-functions/user.remote.ts
@@ -77,11 +77,13 @@ export const updateUserTokensBalance = query(
 			body: JSON.stringify({ balanceChange })
 		});
 
-		if (!response.ok) {
-			console.error('Error updating user balance:', response.statusText);
+		if (response.ok) {
+			console.log('User tokens balance updated successfully');
+			return { success: true };
+		} else {
+			console.error('Error updating user tokens balance:', response.statusText);
+			return { success: false };
 		}
-		const data = await response.json();
-		return { data, error: response.ok ? null : new Error(response.statusText) };
 	}
 );
 

--- a/app/src/routes/+layout.server.ts
+++ b/app/src/routes/+layout.server.ts
@@ -2,7 +2,7 @@ import type { LayoutServerLoad } from './$types';
 import type { Collection, Mixtape } from '../../../shared/types/core';
 import { API_BASE } from '$lib/global/config';
 import type { Listener } from '../../../shared/types/core';
-import type { TrackHydrated } from '../../../shared/types/hydrated';
+import type { ArtistHydrated, TrackHydrated } from '../../../shared/types/hydrated';
 
 export const load: LayoutServerLoad = async ({ locals: { safeGetSession }, cookies, fetch }) => {
 	const { session, user } = await safeGetSession();
@@ -12,6 +12,7 @@ export const load: LayoutServerLoad = async ({ locals: { safeGetSession }, cooki
 	let likedTracks: TrackHydrated[] = [];
 	let followedIDs: string[] = [];
 	let mixtapes: Mixtape[] = [];
+	let linkedArtists: ArtistHydrated[] = [];
 
 	const userId = session?.user.id;
 
@@ -21,6 +22,7 @@ export const load: LayoutServerLoad = async ({ locals: { safeGetSession }, cooki
 		likedTracks = await fetch(`${API_BASE}/users/${userId}/likes`).then((res) => res.json());
 		followedIDs = await fetch(`${API_BASE}/users/${userId}/following`).then((res) => res.json());
 		mixtapes = await fetch(`${API_BASE}/users/${userId}/mixtapes`).then((res) => res.json());
+		linkedArtists = await fetch(`${API_BASE}/users/${userId}/artists`).then((res) => res.json());
 	}
 
 	return {
@@ -31,6 +33,7 @@ export const load: LayoutServerLoad = async ({ locals: { safeGetSession }, cooki
 		likedTracks,
 		mixtapes,
 		followedArtists: followedIDs,
+		linkedArtists,
 		cookies: cookies.getAll()
 	};
 };

--- a/app/src/routes/+layout.svelte
+++ b/app/src/routes/+layout.svelte
@@ -71,12 +71,13 @@
 </main>
 <Footer />
 
-{#if data.session?.user.id && data.profileData && data.likedTracks}
+{#if data.session?.user.id && data.profileData}
 	<StickyNav
 		bind:searchIsOpen
 		userId={data.session?.user.id}
 		userProfileData={data.profileData}
 		userLikedTracks={data.likedTracks}
+		userLinkedArtists={data.linkedArtists}
 	/>
 {/if}
 

--- a/app/src/routes/+layout.ts
+++ b/app/src/routes/+layout.ts
@@ -42,6 +42,7 @@ export const load: LayoutLoad = async ({ fetch, data, depends }) => {
 		profileData: data.profileData,
 		collections: data.collections,
 		followedArtists: data.followedArtists,
+		linkedArtists: data.linkedArtists,
 		likedTracks: data.likedTracks,
 		mixtapes: data.mixtapes
 	};

--- a/app/src/routes/releases/[slug]/+page.svelte
+++ b/app/src/routes/releases/[slug]/+page.svelte
@@ -78,6 +78,13 @@
 		</ButtonWrapper>
 	{/if}
 
+	{#if data.linkedArtists.find((artist) => artist.id === release.artist_id)}
+		<div class="linked-artist-indicator">
+			You will not be charged for streaming this release because you are linked to (or may even be)
+			the artist!
+		</div>
+	{/if}
+
 	<TracksTable
 		tracks={release.tracks.map((track) => ({
 			...track,
@@ -133,5 +140,14 @@
 		text-align: center;
 		font-weight: 400;
 		padding: 0.5rem 1rem;
+	}
+	.linked-artist-indicator {
+		background-color: #4c77a9;
+		color: var(--color-text);
+		padding: 0.5rem 1rem;
+		border-radius: 12px;
+		font-size: 0.9rem;
+		line-height: 1.2;
+		font-weight: 500;
 	}
 </style>

--- a/shared/styles/global.css
+++ b/shared/styles/global.css
@@ -1,7 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Yanone+Kaffeesatz:wght@200..700&display=swap');
 
 :root {
-	--font-size: 1.2rem;
+	--font-size: 1.1rem;
 
 	--color-background: #f0f0f0;
 	--color-background-secondary: #e0e0e0;


### PR DESCRIPTION
Checks if a listener's account is also connected to that of the artist they are listening to. If so the stream is logged but there is no deduction from the user's balance. It seems silly to charge people to listen to their own music. 

This also wades into the waters of 'freebie' listens, which may apply in time to royalty free music on the platform.

As part of these changes I've tried to tighten up the logic around streams being logged and payments being logged so errors don't slip through the net. Before a the pop up saying 'X sent to Jane Doe' appeared regardless of whether the charge and log were successful - now it depends on their success. 